### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/MutinyHQ/mdiff/compare/v0.1.1...v0.1.2) - 2026-02-18
+
+### Other
+
+- use GH_ACTION_PAT for release-plz workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/MutinyHQ/mdiff/compare/v0.1.1...v0.1.2) - 2026-02-18

### Other

- use GH_ACTION_PAT for release-plz workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).