### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/MutinyHQ/mdiff/compare/v0.1.2...v0.1.3) - 2026-02-18
+
+### Added
+
+- add confirm modal for destructive restore command
+- wrap and scroll text input in all modals, add Shift+Enter for newlines
+
+### Fixed
+
+- always use all files and annotations for agent prompt, clear after dispatch
+
+### Other
+
+- cargo fmt
+
 ## [0.1.2](https://github.com/MutinyHQ/mdiff/compare/v0.1.1...v0.1.2) - 2026-02-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/MutinyHQ/mdiff/compare/v0.1.2...v0.1.3) - 2026-02-18

### Added

- add confirm modal for destructive restore command
- wrap and scroll text input in all modals, add Shift+Enter for newlines

### Fixed

- always use all files and annotations for agent prompt, clear after dispatch

### Other

- cargo fmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).