### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/MutinyHQ/mdiff/compare/v0.1.3...v0.1.4) - 2026-02-18
+
+### Added
+
+- auto-review on scroll-to-bottom, add review keys to HUD
+- persist last-used model per agent CLI, PTY runner, review tracking
+- allow V to toggle visual mode
+- allow creating annotation at cursor without visual mode
+
+### Fixed
+
+- remove managed scrolling in agent outputs to prevent vt100 panic
+- mouse scroll in agent outputs view, opencode --prompt flag
+- use vt100 scrollback buffer for PTY output scrolling
+- interleave comments with diff context in review prompt
+- scoped diffs in agent prompt, deletion line positioning, and UI clarity
+- render agent outputs from top of PTY screen, fix scrolling
+
+### Other
+
+- simplify PTY terminal row rendering in agent outputs
+
 ## [0.1.3](https://github.com/MutinyHQ/mdiff/compare/v0.1.2...v0.1.3) - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/MutinyHQ/mdiff/compare/v0.1.3...v0.1.4) - 2026-02-18

### Added

- auto-review on scroll-to-bottom, add review keys to HUD
- persist last-used model per agent CLI, PTY runner, review tracking
- allow V to toggle visual mode
- allow creating annotation at cursor without visual mode

### Fixed

- remove managed scrolling in agent outputs to prevent vt100 panic
- mouse scroll in agent outputs view, opencode --prompt flag
- use vt100 scrollback buffer for PTY output scrolling
- interleave comments with diff context in review prompt
- scoped diffs in agent prompt, deletion line positioning, and UI clarity
- render agent outputs from top of PTY screen, fix scrolling

### Other

- simplify PTY terminal row rendering in agent outputs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).