### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/MutinyHQ/mdiff/compare/v0.1.5...v0.1.6) - 2026-02-18
+
+### Added
+
+- forward mouse scroll to PTY in agent outputs view
+
+### Fixed
+
+- use content highlight instead of gutter color for search matches
+- set agent subprocess cwd to repo_path so agents start in the correct directory
+
 ## [0.1.5](https://github.com/MutinyHQ/mdiff/compare/v0.1.4...v0.1.5) - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/MutinyHQ/mdiff/compare/v0.1.5...v0.1.6) - 2026-02-18

### Added

- forward mouse scroll to PTY in agent outputs view

### Fixed

- use content highlight instead of gutter color for search matches
- set agent subprocess cwd to repo_path so agents start in the correct directory
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).