### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/MutinyHQ/mdiff/compare/v0.1.6...v0.1.7) - 2026-02-18
+
+### Added
+
+- use 3-dot diff (merge-base) for branch and commit comparisons
+
 ## [0.1.6](https://github.com/MutinyHQ/mdiff/compare/v0.1.5...v0.1.6) - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/MutinyHQ/mdiff/compare/v0.1.6...v0.1.7) - 2026-02-18

### Added

- use 3-dot diff (merge-base) for branch and commit comparisons
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).