### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/MutinyHQ/mdiff/compare/v0.1.8...v0.1.9) - 2026-02-19
+
+### Fixed
+
+- truncate file paths from the left in navigator on narrow screens
+- synchronize line wrapping in split diff view
+
 ## [0.1.8](https://github.com/MutinyHQ/mdiff/compare/v0.1.7...v0.1.8) - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/MutinyHQ/mdiff/compare/v0.1.8...v0.1.9) - 2026-02-19

### Fixed

- truncate file paths from the left in navigator on narrow screens
- synchronize line wrapping in split diff view
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).