### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/MutinyHQ/mdiff/compare/v0.1.10...v0.1.11) - 2026-03-04
+
+### Fixed
+
+- clippy
+- PTY process cleanup, kill targeting, and paste support
+
+### Other
+
+- add implementation spec for annotation quick-reactions
+- add implementation spec for contextual help overlay (which-key)
+- add implementation spec for agent feedback summary view
+- add 7 new feature ideas from competitive research (2026-03-05)
+- add implementation spec for annotation categories and severity levels
+- add implementation spec for hunk-level navigation
+- add comprehensive roadmap and feature backlog
+
 ## [0.1.10](https://github.com/MutinyHQ/mdiff/compare/v0.1.9...v0.1.10) - 2026-02-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/MutinyHQ/mdiff/compare/v0.1.10...v0.1.11) - 2026-03-04

### Fixed

- clippy
- PTY process cleanup, kill targeting, and paste support

### Other

- add implementation spec for annotation quick-reactions
- add implementation spec for contextual help overlay (which-key)
- add implementation spec for agent feedback summary view
- add 7 new feature ideas from competitive research (2026-03-05)
- add implementation spec for annotation categories and severity levels
- add implementation spec for hunk-level navigation
- add comprehensive roadmap and feature backlog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).