### PR TITLE
Annotation line scores

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -139,6 +139,10 @@ pub enum Action {
     CopyPromptToClipboard,
     TogglePromptPreview,
 
+    // Quick-reaction scores
+    SetLineScore(u8),
+    RemoveLineScore,
+
     // Agent selector
     OpenAgentSelector,
     AgentSelectorUp,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1481,6 +1481,52 @@ impl App {
                 }
             }
 
+            // Quick-reaction scores
+            Action::SetLineScore(value) => {
+                let anchor = if self.state.selection.active {
+                    self.selection_to_anchor()
+                } else {
+                    self.cursor_to_anchor()
+                };
+
+                if let Some(anchor) = anchor {
+                    let score = crate::state::annotation_state::LineScore {
+                        file_path: anchor.file_path.clone(),
+                        old_range: anchor.old_range,
+                        new_range: anchor.new_range,
+                        score: value,
+                        created_at: chrono::Utc::now().to_rfc3339(),
+                    };
+                    self.state.annotations.set_score(score);
+
+                    if self.state.selection.active {
+                        self.state.selection.active = false;
+                    }
+
+                    let dots = "●".repeat(value as usize) + &"○".repeat(5 - value as usize);
+                    self.set_status(format!("Score: {} ({}/5)", dots, value), false);
+                }
+            }
+            Action::RemoveLineScore => {
+                let anchor = if self.state.selection.active {
+                    self.selection_to_anchor()
+                } else {
+                    self.cursor_to_anchor()
+                };
+
+                if let Some(anchor) = anchor {
+                    self.state.annotations.remove_score(
+                        &anchor.file_path,
+                        anchor.old_range,
+                        anchor.new_range,
+                    );
+                    if self.state.selection.active {
+                        self.state.selection.active = false;
+                    }
+                    self.set_status("Score removed".to_string(), false);
+                }
+            }
+
             // Agent selector
             Action::OpenAgentSelector => {
                 if self.config.agents.is_empty() {
@@ -2459,7 +2505,7 @@ impl App {
             }
         }
 
-        if file_sections.is_empty() {
+        if file_sections.is_empty() && self.state.annotations.score_count() == 0 {
             return None;
         }
 
@@ -2469,7 +2515,6 @@ impl App {
              a question, answer it and make any implied fixes. Keep changes minimal and focused \
              on what the reviewer asked for.\n\n",
         );
-
         // Add checklist status if checklist is configured
         if !self.state.checklist.is_empty() {
             prompt.push_str("## Review Checklist\n");
@@ -2484,7 +2529,28 @@ impl App {
             prompt.push('\n');
         }
 
-        prompt.push_str(&file_sections.join("\n\n"));
+        // Add scores section if present
+        let all_scores = self.state.annotations.all_scores_sorted();
+        if !all_scores.is_empty() {
+            prompt.push_str("### Scores\n");
+            for score in &all_scores {
+                let range = match score.new_range {
+                    Some((s, e)) if s == e => format!("{}:{}", score.file_path, s),
+                    Some((s, e)) => format!("{}:{}-{}", score.file_path, s, e),
+                    None => match score.old_range {
+                        Some((s, e)) if s == e => format!("{}:{} (old)", score.file_path, s),
+                        Some((s, e)) => format!("{}:{}-{} (old)", score.file_path, s, e),
+                        None => score.file_path.clone(),
+                    },
+                };
+                prompt.push_str(&format!("- {} [Score: {}/5]\n", range, score.score));
+            }
+            prompt.push('\n');
+        }
+
+        if !file_sections.is_empty() {
+            prompt.push_str(&file_sections.join("\n\n"));
+        }
 
         Some(prompt)
     }

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -187,6 +187,26 @@ fn has_annotation(state: &AppState, delta: &FileDelta, row_info: &DisplayRowInfo
         .has_annotation_at(&file_path, row_info.old_lineno, row_info.new_lineno)
 }
 
+/// Get the score at a line position, if any.
+fn get_score(state: &AppState, delta: &FileDelta, row_info: &DisplayRowInfo) -> Option<u8> {
+    let file_path = delta.path.to_string_lossy();
+    state
+        .annotations
+        .score_at(&file_path, row_info.old_lineno, row_info.new_lineno)
+}
+
+/// Get the color for a score value.
+fn score_color(score: u8) -> Color {
+    match score {
+        1 => Color::Red,
+        2 => Color::Rgb(255, 165, 0), // Orange
+        3 => Color::Yellow,
+        4 => Color::Rgb(144, 238, 144), // Light green
+        5 => Color::Green,
+        _ => Color::Gray,
+    }
+}
+
 fn render_split(
     frame: &mut Frame,
     area: Rect,
@@ -384,7 +404,16 @@ fn build_split_lines_core<'a>(
         if let Some(bg) = hl.gutter_bg {
             gutter_style = gutter_style.bg(bg);
         }
-        center.push(Line::from(Span::styled(hunk_gutter, gutter_style)));
+
+        let score = display_map
+            .get(display_row)
+            .and_then(|info| get_score(state, delta, info));
+        let mut hunk_spans = Vec::new();
+        if let Some(s) = score {
+            hunk_spans.push(Span::styled("●", Style::default().fg(score_color(s))));
+        }
+        hunk_spans.push(Span::styled(hunk_gutter, gutter_style));
+        center.push(Line::from(hunk_spans));
 
         let mut content_style = Style::default().fg(theme.text_muted);
         if let Some(bg) = hl.content_bg {
@@ -424,7 +453,17 @@ fn build_split_lines_core<'a>(
                     if let Some(bg) = hl.gutter_bg {
                         gutter_style = gutter_style.bg(bg);
                     }
-                    center.push(Line::from(Span::styled(collapsed_gutter, gutter_style)));
+
+                    let score = display_map
+                        .get(display_row)
+                        .and_then(|info| get_score(state, delta, info));
+                    let mut collapsed_spans = Vec::new();
+                    if let Some(s) = score {
+                        collapsed_spans
+                            .push(Span::styled("●", Style::default().fg(score_color(s))));
+                    }
+                    collapsed_spans.push(Span::styled(collapsed_gutter, gutter_style));
+                    center.push(Line::from(collapsed_spans));
 
                     let mut content_style = Style::default().fg(theme.text_muted);
                     if let Some(bg) = hl.content_bg {
@@ -451,8 +490,11 @@ fn build_split_lines_core<'a>(
                         let gutter_l = format_lineno(line.old_lineno, gutter_width);
                         let gutter_r = format_lineno(line.new_lineno, gutter_width);
                         let marker = if ann_marker { "\u{2502}" } else { " " };
+                        let score = display_map
+                            .get(display_row)
+                            .and_then(|info| get_score(state, delta, info));
                         center.push(make_center_gutter_line(
-                            &gutter_l, &gutter_r, marker, hl, theme,
+                            &gutter_l, &gutter_r, marker, hl, theme, score,
                         ));
 
                         let old_spans = line.old_lineno.and_then(|n| old_hl.get(n as usize));
@@ -539,8 +581,11 @@ fn build_split_lines_core<'a>(
                             };
                             let gutter_l = format_lineno(old_lineno, gutter_width);
                             let gutter_r = format_lineno(new_lineno, gutter_width);
+                            let score = display_map
+                                .get(display_row)
+                                .and_then(|info| get_score(state, delta, info));
                             center.push(make_center_gutter_line(
-                                &gutter_l, &gutter_r, marker, hl, theme,
+                                &gutter_l, &gutter_r, marker, hl, theme, score,
                             ));
 
                             if j < dels.len() {
@@ -583,8 +628,11 @@ fn build_split_lines_core<'a>(
 
                         let gutter_l = " ".repeat(gutter_width);
                         let gutter_r = format_lineno(line.new_lineno, gutter_width);
+                        let score = display_map
+                            .get(display_row)
+                            .and_then(|info| get_score(state, delta, info));
                         center.push(make_center_gutter_line(
-                            &gutter_l, &gutter_r, marker, hl, theme,
+                            &gutter_l, &gutter_r, marker, hl, theme, score,
                         ));
 
                         left.push(make_empty_content_line(hl, theme));
@@ -625,12 +673,16 @@ fn build_unified_lines_core<'a>(
         let ann_marker = display_map
             .get(display_row)
             .is_some_and(|info| has_annotation(state, delta, info));
+        let score = display_map
+            .get(display_row)
+            .and_then(|info| get_score(state, delta, info));
 
         lines.push(make_hunk_header_line_unified(
             gutter_width,
             &hunk.header,
             hl,
             ann_marker,
+            score,
             theme,
         ));
         display_row += 1;
@@ -651,11 +703,15 @@ fn build_unified_lines_core<'a>(
                     ..
                 } => {
                     let hl = row_highlight(state, display_row);
+                    let score = display_map
+                        .get(display_row)
+                        .and_then(|info| get_score(state, delta, info));
                     lines.push(make_collapsed_indicator_line_unified(
                         gutter_width,
                         *hidden_count,
                         *direction,
                         hl,
+                        score,
                         theme,
                     ));
                     display_row += 1;
@@ -665,6 +721,9 @@ fn build_unified_lines_core<'a>(
                     let ann_marker = display_map
                         .get(display_row)
                         .is_some_and(|info| has_annotation(state, delta, info));
+                    let score = display_map
+                        .get(display_row)
+                        .and_then(|info| get_score(state, delta, info));
 
                     let (old_g, new_g) = (
                         format_lineno(line.old_lineno, gutter_width),
@@ -683,6 +742,7 @@ fn build_unified_lines_core<'a>(
                                 None,
                                 hl,
                                 ann_marker,
+                                score,
                                 theme,
                             ));
                         }
@@ -698,6 +758,7 @@ fn build_unified_lines_core<'a>(
                                 Some(theme.diff_add_bg),
                                 hl,
                                 ann_marker,
+                                score,
                                 theme,
                             ));
                         }
@@ -713,6 +774,7 @@ fn build_unified_lines_core<'a>(
                                 Some(theme.diff_del_bg),
                                 hl,
                                 ann_marker,
+                                score,
                                 theme,
                             ));
                         }
@@ -741,6 +803,7 @@ fn make_hunk_header_line_unified<'a>(
     header: &str,
     hl: RowHighlight,
     ann_marker: bool,
+    score: Option<u8>,
     theme: &Theme,
 ) -> Line<'a> {
     let marker = if ann_marker { "\u{2502}" } else { " " };
@@ -758,10 +821,14 @@ fn make_hunk_header_line_unified<'a>(
     if let Some(bg) = hl.content_bg {
         content_style = content_style.bg(bg);
     }
-    Line::from(vec![
-        Span::styled(gutter_text, gutter_style),
-        Span::styled(header.to_string(), content_style),
-    ])
+
+    let mut spans = Vec::new();
+    if let Some(s) = score {
+        spans.push(Span::styled("●", Style::default().fg(score_color(s))));
+    }
+    spans.push(Span::styled(gutter_text, gutter_style));
+    spans.push(Span::styled(header.to_string(), content_style));
+    Line::from(spans)
 }
 
 /// Apply highlight spans to a string, blending with diff background.
@@ -826,7 +893,16 @@ fn make_center_gutter_line<'a>(
     marker: &str,
     hl: RowHighlight,
     theme: &Theme,
+    score: Option<u8>,
 ) -> Line<'a> {
+    let mut spans = Vec::new();
+
+    // Add score dot if present
+    if let Some(s) = score {
+        let dot_style = Style::default().fg(score_color(s));
+        spans.push(Span::styled("●", dot_style));
+    }
+
     let text = format!("{gutter_l} {gutter_r}{marker}");
     let mut style = Style::default().fg(theme.text_muted);
     if marker == "\u{2502}" {
@@ -838,7 +914,9 @@ fn make_center_gutter_line<'a>(
     if let Some(bg) = hl.gutter_bg {
         style = style.bg(bg);
     }
-    Line::from(Span::styled(text, style))
+    spans.push(Span::styled(text, style));
+
+    Line::from(spans)
 }
 
 /// Build a content-only line (no gutter) with syntax highlighting and diff background.
@@ -897,6 +975,7 @@ fn make_unified_highlighted<'a>(
     diff_bg: Option<Color>,
     hl: RowHighlight,
     ann_marker: bool,
+    score: Option<u8>,
     theme: &Theme,
 ) -> Line<'a> {
     let trimmed = content.trim_end_matches('\n');
@@ -913,7 +992,13 @@ fn make_unified_highlighted<'a>(
     if let Some(bg) = hl.gutter_bg {
         gutter_style = gutter_style.bg(bg);
     }
+
+    let mut all_spans = Vec::new();
+    if let Some(s) = score {
+        all_spans.push(Span::styled("●", Style::default().fg(score_color(s))));
+    }
     let gutter_span = Span::styled(format!("{old_g} {new_g}{marker}"), gutter_style);
+    all_spans.push(gutter_span);
 
     let prefix_style = match prefix {
         "+" => Style::default()
@@ -942,7 +1027,7 @@ fn make_unified_highlighted<'a>(
         vec![Span::styled(trimmed.to_string(), style)]
     };
 
-    let mut all_spans = vec![gutter_span, prefix_span];
+    all_spans.push(prefix_span);
     all_spans.extend(content_spans);
     Line::from(all_spans)
 }
@@ -953,6 +1038,7 @@ fn make_collapsed_indicator_line_unified<'a>(
     hidden_count: usize,
     direction: ExpandDirection,
     hl: RowHighlight,
+    score: Option<u8>,
     theme: &Theme,
 ) -> Line<'a> {
     let gutter_text = format!(
@@ -975,10 +1061,14 @@ fn make_collapsed_indicator_line_unified<'a>(
         ExpandDirection::Up => "\u{25b2}",   // ▲
     };
     let label = format!("{caret} {hidden_count} lines hidden {caret}");
-    Line::from(vec![
-        Span::styled(gutter_text, gutter_style),
-        Span::styled(label, content_style),
-    ])
+
+    let mut spans = Vec::new();
+    if let Some(s) = score {
+        spans.push(Span::styled("●", Style::default().fg(score_color(s))));
+    }
+    spans.push(Span::styled(gutter_text, gutter_style));
+    spans.push(Span::styled(label, content_style));
+    Line::from(spans)
 }
 
 /// Wrap left and right split-view lines in lockstep so each logical row occupies the same

--- a/src/event.rs
+++ b/src/event.rs
@@ -558,6 +558,12 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
             KeyCode::Char('d') => Some(Action::DeleteAnnotation),
             KeyCode::Char('y') => Some(Action::CopyPromptToClipboard),
             KeyCode::Char('v') | KeyCode::Char('V') | KeyCode::Esc => Some(Action::ExitVisualMode),
+            KeyCode::Char('1') => Some(Action::SetLineScore(1)),
+            KeyCode::Char('2') => Some(Action::SetLineScore(2)),
+            KeyCode::Char('3') => Some(Action::SetLineScore(3)),
+            KeyCode::Char('4') => Some(Action::SetLineScore(4)),
+            KeyCode::Char('5') => Some(Action::SetLineScore(5)),
+            KeyCode::Char('0') => Some(Action::RemoveLineScore),
             _ => None,
         };
     }
@@ -588,6 +594,12 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
             KeyCode::Char('y') => Some(Action::CopyPromptToClipboard),
             KeyCode::Char('a') => Some(Action::OpenAnnotationMenu),
             KeyCode::Char('N') => Some(Action::DiffSearchPrev),
+            KeyCode::Char('1') => Some(Action::SetLineScore(1)),
+            KeyCode::Char('2') => Some(Action::SetLineScore(2)),
+            KeyCode::Char('3') => Some(Action::SetLineScore(3)),
+            KeyCode::Char('4') => Some(Action::SetLineScore(4)),
+            KeyCode::Char('5') => Some(Action::SetLineScore(5)),
+            KeyCode::Char('0') => Some(Action::RemoveLineScore),
             _ => None,
         },
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,6 +14,8 @@ struct SessionFile {
     annotations: Vec<AnnotationEntry>,
     #[serde(default)]
     checklist: Option<ChecklistSessionData>,
+    #[serde(default)]
+    scores: Vec<ScoreEntry>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -47,6 +49,18 @@ struct AnnotationEntry {
     #[serde(default)]
     line_end: Option<u32>,
     comment: String,
+    created_at: String,
+}
+
+/// Score entry for session persistence.
+#[derive(Serialize, Deserialize)]
+struct ScoreEntry {
+    file_path: String,
+    old_start: Option<u32>,
+    old_end: Option<u32>,
+    new_start: Option<u32>,
+    new_end: Option<u32>,
+    score: u8,
     created_at: String,
 }
 
@@ -150,6 +164,19 @@ pub fn load_session_data(
         }
     });
 
+    // Load scores
+    for entry in session.scores {
+        let old_range = entry.old_start.zip(entry.old_end);
+        let new_range = entry.new_start.zip(entry.new_end);
+        annotations_state.set_score(crate::state::annotation_state::LineScore {
+            file_path: entry.file_path,
+            old_range,
+            new_range,
+            score: entry.score,
+            created_at: entry.created_at,
+        });
+    }
+
     (annotations_state, checklist_state)
 }
 
@@ -197,11 +224,26 @@ pub fn save_session_data(
             .collect(),
     });
 
+    let score_entries: Vec<ScoreEntry> = annotations
+        .all_scores_sorted()
+        .into_iter()
+        .map(|s| ScoreEntry {
+            file_path: s.file_path.clone(),
+            old_start: s.old_range.map(|(s, _)| s),
+            old_end: s.old_range.map(|(_, e)| e),
+            new_start: s.new_range.map(|(s, _)| s),
+            new_end: s.new_range.map(|(_, e)| e),
+            score: s.score,
+            created_at: s.created_at.clone(),
+        })
+        .collect();
+
     let session = SessionFile {
         version: if checklist_data.is_some() { 3 } else { 2 },
         target_label: target_label.to_string(),
         annotations: entries,
         checklist: checklist_data,
+        scores: score_entries,
     };
 
     if let Ok(json) = serde_json::to_string_pretty(&session) {

--- a/src/state/annotation_state.rs
+++ b/src/state/annotation_state.rs
@@ -95,6 +95,26 @@ pub struct LineAnchor {
     pub new_range: Option<(u32, u32)>, // (start, end) in new file
 }
 
+/// A quick-reaction score attached to a line or range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineScore {
+    pub file_path: String,
+    pub old_range: Option<(u32, u32)>,
+    pub new_range: Option<(u32, u32)>,
+    pub score: u8, // 1-5
+    pub created_at: String,
+}
+
+impl LineScore {
+    /// Representative line for sorting.
+    pub fn sort_line(&self) -> u32 {
+        self.new_range
+            .map(|(s, _)| s)
+            .or(self.old_range.map(|(s, _)| s))
+            .unwrap_or(0)
+    }
+}
+
 impl LineAnchor {
     /// A single representative line number for sorting/navigation.
     /// Prefers new-file start, falls back to old-file start.
@@ -178,6 +198,8 @@ fn default_severity() -> AnnotationSeverity {
 pub struct AnnotationState {
     /// Map of file_path → list of annotations on that file.
     pub annotations: BTreeMap<String, Vec<Annotation>>,
+    /// Quick-reaction scores (separate from annotations).
+    pub scores: BTreeMap<String, Vec<LineScore>>,
 }
 
 impl AnnotationState {
@@ -320,24 +342,74 @@ impl AnnotationState {
             .map(|a| (a.anchor.file_path.as_str(), a.anchor.sort_line()))
     }
 
-    /// Total count of scores (placeholder for spec 003 - quick-reactions).
+    /// Set a score for a line/range. Replaces any existing score at the same position.
+    pub fn set_score(&mut self, score: LineScore) {
+        let key = score.file_path.clone();
+        let entries = self.scores.entry(key).or_default();
+        // Remove any existing score at the same position
+        entries.retain(|s| s.old_range != score.old_range || s.new_range != score.new_range);
+        entries.push(score);
+    }
+
+    /// Remove score at a position.
+    pub fn remove_score(
+        &mut self,
+        file_path: &str,
+        old_range: Option<(u32, u32)>,
+        new_range: Option<(u32, u32)>,
+    ) {
+        if let Some(scores) = self.scores.get_mut(file_path) {
+            scores.retain(|s| s.old_range != old_range || s.new_range != new_range);
+            if scores.is_empty() {
+                self.scores.remove(file_path);
+            }
+        }
+    }
+
+    /// Get score at a specific line position.
+    pub fn score_at(
+        &self,
+        file_path: &str,
+        old_lineno: Option<u32>,
+        new_lineno: Option<u32>,
+    ) -> Option<u8> {
+        self.scores.get(file_path).and_then(|scores| {
+            scores.iter().find_map(|s| {
+                let covers_new = matches!(
+                    (new_lineno, s.new_range),
+                    (Some(n), Some((start, end))) if n >= start && n <= end
+                );
+                let covers_old = matches!(
+                    (old_lineno, s.old_range),
+                    (Some(n), Some((start, end))) if n >= start && n <= end
+                );
+                let covers = covers_new || covers_old;
+                if covers {
+                    Some(s.score)
+                } else {
+                    None
+                }
+            })
+        })
+    }
+
+    /// Get all scores as a flat sorted list.
+    pub fn all_scores_sorted(&self) -> Vec<&LineScore> {
+        let mut result: Vec<&LineScore> = self.scores.values().flat_map(|v| v.iter()).collect();
+        result.sort_by_key(|s| (&s.file_path, s.sort_line()));
+        result
+    }
+
+    /// Total score count.
     pub fn score_count(&self) -> usize {
-        0
+        self.scores.values().map(|v| v.len()).sum()
     }
 
-    /// Get all scores sorted (placeholder for spec 003 - quick-reactions).
-    pub fn all_scores_sorted(&self) -> Vec<LineScore> {
-        Vec::new()
-    }
-
-    /// Count files that have annotations.
+    /// Count files that have any feedback (annotations and/or scores).
     pub fn files_with_annotations(&self) -> usize {
-        self.annotations.len()
+        let mut files = std::collections::BTreeSet::new();
+        files.extend(self.annotations.keys().map(String::as_str));
+        files.extend(self.scores.keys().map(String::as_str));
+        files.len()
     }
-}
-
-/// Placeholder for line score (spec 003 - quick-reactions).
-#[derive(Debug, Clone)]
-pub struct LineScore {
-    pub score: u8,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement the "Annotation Quick-Reactions" feature to allow single-key line scoring on diffs, with scores appearing in the gutter and prompt output.

---
<p><a href="https://cursor.com/agents/bc-66e5ab11-75ff-49dc-9af4-ba299e278560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66e5ab11-75ff-49dc-9af4-ba299e278560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->