### PR TITLE
chore: release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/MutinyHQ/mdiff/compare/v0.1.11...v0.1.12) - 2026-03-06
+
+### Added
+
+- implement Agent Feedback Summary View
+- ellipsis diff paths in the middle
+
+### Fixed
+
+- address clippy warnings and format code
+
+### Other
+
+- Add global fuzzy search across all diff content (Ctrl+F)
+- add workflow_dispatch trigger for manual runs
+- Add AGENTS.md with Cursor Cloud specific instructions
+- Merge branch 'main' into cursor/which-key-overlay-23bc
+- Merge pull request #19 from MutinyHQ/alechoey/confirm-exit
+
 ## [0.1.11](https://github.com/MutinyHQ/mdiff/compare/v0.1.10...v0.1.11) - 2026-03-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.12](https://github.com/MutinyHQ/mdiff/compare/v0.1.11...v0.1.12) - 2026-03-06

### Added

- implement Agent Feedback Summary View
- ellipsis diff paths in the middle

### Fixed

- address clippy warnings and format code

### Other

- Add global fuzzy search across all diff content (Ctrl+F)
- add workflow_dispatch trigger for manual runs
- Add AGENTS.md with Cursor Cloud specific instructions
- Merge branch 'main' into cursor/which-key-overlay-23bc
- Merge pull request #19 from MutinyHQ/alechoey/confirm-exit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).