### PR TITLE
feat: Agent Guidance Export (Structured Feedback as Agent Instructions)

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -202,8 +202,12 @@ pub enum Action {
     FeedbackSummaryCopyJson,
     FeedbackSummaryCopyPrompt,
 
-    // Feedback export
+    // Feedback export (legacy direct JSON export, now accessed via format picker)
+    #[allow(dead_code)]
     ExportFeedback,
+    OpenExportFormatPicker,
+    SelectExportFormat(crate::export::ExportFormat),
+    CancelExportFormatPicker,
 
     // Generic text input navigation
     TextCursorLeft,

--- a/src/app.rs
+++ b/src/app.rs
@@ -275,6 +275,13 @@ impl App {
                 if self.state.global_search.active {
                     render_global_search_bar(frame, &self.state);
                 }
+                if self.state.export_format_picker_open {
+                    crate::components::export_picker::render_export_picker(
+                        frame,
+                        frame.area(),
+                        &self.state,
+                    );
+                }
                 which_key::render_which_key(frame, frame.area(), &self.state);
             })?;
 
@@ -317,6 +324,7 @@ impl App {
                     which_key_visible: self.state.which_key_visible,
                     tree_mode: self.state.navigator.tree_mode,
                     tree_z_pending: self.tree_z_pending,
+                    export_format_picker_open: self.state.export_format_picker_open,
                 };
                 let action = match event {
                     Event::Key(key) => {
@@ -339,6 +347,7 @@ impl App {
                             || ctx.annotation_menu_open
                             || ctx.restore_confirm_open
                             || ctx.settings_open
+                            || ctx.export_format_picker_open
                             || ctx.search_active
                             || ctx.diff_search_active
                         {
@@ -2135,6 +2144,79 @@ impl App {
                 ) {
                     Ok(path) => {
                         self.set_status(format!("Exported to {}", path.display()), false);
+                    }
+                    Err(e) => {
+                        self.set_status(format!("Export failed: {e}"), true);
+                    }
+                }
+            }
+            Action::OpenExportFormatPicker => {
+                if self.state.annotations.count() == 0 && self.state.annotations.score_count() == 0
+                {
+                    self.set_status("No annotations to export".to_string(), true);
+                } else {
+                    self.state.export_format_picker_open = true;
+                }
+            }
+            Action::CancelExportFormatPicker => {
+                self.state.export_format_picker_open = false;
+            }
+            Action::SelectExportFormat(format) => {
+                self.state.export_format_picker_open = false;
+                crate::export::ensure_gitignore(&self.repo_path);
+                match crate::export::export_with_format(
+                    &self.state,
+                    &self.repo_path,
+                    &self.state.target_label,
+                    format,
+                ) {
+                    Ok(crate::export::ExportResult::File(path)) => {
+                        self.set_status(
+                            format!("Exported {} to {}", format.label(), path.display()),
+                            false,
+                        );
+                    }
+                    Ok(crate::export::ExportResult::Text(text)) => {
+                        match arboard::Clipboard::new() {
+                            Ok(mut clipboard) => {
+                                let _ = clipboard.set_text(&text);
+                                self.set_status(
+                                    format!(
+                                        "{} copied to clipboard ({} chars)",
+                                        format.label(),
+                                        text.len()
+                                    ),
+                                    false,
+                                );
+                            }
+                            Err(_) => {
+                                // Clipboard unavailable — write to file instead
+                                match crate::export::export_with_format(
+                                    &self.state,
+                                    &self.repo_path,
+                                    &self.state.target_label,
+                                    crate::export::ExportFormat::Json,
+                                ) {
+                                    Ok(crate::export::ExportResult::File(path)) => {
+                                        self.set_status(
+                                            format!(
+                                                "Clipboard unavailable. {} saved to {}",
+                                                format.label(),
+                                                path.display()
+                                            ),
+                                            false,
+                                        );
+                                    }
+                                    _ => {
+                                        self.set_status(
+                                            "Clipboard unavailable and file export failed"
+                                                .to_string(),
+                                            true,
+                                        );
+                                    }
+                                }
+                            }
+                        }
                     }
                     Err(e) => {
                         self.set_status(format!("Export failed: {e}"), true);

--- a/src/components/export_picker.rs
+++ b/src/components/export_picker.rs
@@ -1,0 +1,52 @@
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::export::ExportFormat;
+use crate::state::AppState;
+
+pub fn render_export_picker(frame: &mut Frame, area: Rect, state: &AppState) {
+    if !state.export_format_picker_open {
+        return;
+    }
+
+    let theme = &state.theme;
+
+    let height = 3;
+    let picker_area = Rect {
+        x: area.x + 1,
+        y: area.y + area.height.saturating_sub(height + 1),
+        width: area.width.saturating_sub(2),
+        height,
+    };
+
+    frame.render_widget(Clear, picker_area);
+
+    let items: Vec<Span> = ExportFormat::all()
+        .iter()
+        .flat_map(|fmt| {
+            vec![
+                Span::styled(
+                    format!("[{}]", fmt.shortcut()),
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{} ", fmt.label()), Style::default().fg(theme.text)),
+            ]
+        })
+        .collect();
+
+    let title = " Export Format (Esc=cancel) ";
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent));
+    let paragraph = Paragraph::new(Line::from(items)).block(block);
+
+    frame.render_widget(paragraph, picker_area);
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -8,6 +8,7 @@ pub mod comment_editor;
 pub mod commit_dialog;
 pub mod context_bar;
 pub mod diff_view;
+pub mod export_picker;
 pub mod feedback_summary;
 pub mod global_search_bar;
 pub mod navigator;

--- a/src/components/which_key.rs
+++ b/src/components/which_key.rs
@@ -324,7 +324,7 @@ fn get_context_entries(state: &AppState) -> Vec<KeyEntry> {
                     },
                     KeyEntry {
                         key: "Ctrl+E",
-                        description: "Export feedback",
+                        description: "Export (format picker)",
                     },
                     KeyEntry {
                         key: "Tab",
@@ -432,7 +432,7 @@ fn get_context_entries(state: &AppState) -> Vec<KeyEntry> {
                 },
                 KeyEntry {
                     key: "Ctrl+E",
-                    description: "Export feedback",
+                    description: "Export (format picker)",
                 },
                 KeyEntry {
                     key: "?",

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 
 use crate::action::Action;
 use crate::action::QuitCombo;
+use crate::export::ExportFormat;
 use crate::state::annotation_state::{AnnotationCategory, AnnotationSeverity};
 use crate::state::app_state::{ActiveView, CategoryPickerPhase, FocusPanel};
 use crate::state::navigator_state::NavigatorEntry;
@@ -110,6 +111,7 @@ pub struct KeyContext {
     pub which_key_visible: bool,
     pub tree_mode: bool,
     pub tree_z_pending: bool,
+    pub export_format_picker_open: bool,
 }
 
 /// Context for mouse event mapping.
@@ -281,6 +283,29 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
                 };
             }
         }
+    }
+
+    // Priority 2.05: Export format picker
+    if ctx.export_format_picker_open {
+        return match key.code {
+            KeyCode::Char('J') | KeyCode::Char('j') => {
+                Some(Action::SelectExportFormat(ExportFormat::Json))
+            }
+            KeyCode::Char('M') | KeyCode::Char('m') => {
+                Some(Action::SelectExportFormat(ExportFormat::Markdown))
+            }
+            KeyCode::Char('A') | KeyCode::Char('a') => {
+                Some(Action::SelectExportFormat(ExportFormat::AgentGuidance))
+            }
+            KeyCode::Char('C') | KeyCode::Char('c') => {
+                Some(Action::SelectExportFormat(ExportFormat::ClaudeMd))
+            }
+            KeyCode::Char('G') | KeyCode::Char('g') => {
+                Some(Action::SelectExportFormat(ExportFormat::GitTrailers))
+            }
+            KeyCode::Esc => Some(Action::CancelExportFormatPicker),
+            _ => None,
+        };
     }
 
     // Priority 2: Comment editor mode
@@ -460,7 +485,7 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
             return Some(Action::StartGlobalSearch)
         }
         KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            return Some(Action::ExportFeedback)
+            return Some(Action::OpenExportFormatPicker)
         }
         _ => {}
     }
@@ -692,6 +717,7 @@ mod tests {
             which_key_visible: false,
             tree_mode: false,
             tree_z_pending: false,
+            export_format_picker_open: false,
         }
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,8 +2,50 @@ use chrono::Utc;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
+use crate::state::annotation_state::{AnnotationCategory, AnnotationSeverity};
 use crate::state::review_state::FileReviewStatus;
 use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFormat {
+    Json,
+    Markdown,
+    AgentGuidance,
+    ClaudeMd,
+    GitTrailers,
+}
+
+impl ExportFormat {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Json => "JSON",
+            Self::Markdown => "Markdown",
+            Self::AgentGuidance => "Agent Guidance",
+            Self::ClaudeMd => "CLAUDE.md Patch",
+            Self::GitTrailers => "Git Trailers",
+        }
+    }
+
+    pub fn shortcut(&self) -> char {
+        match self {
+            Self::Json => 'J',
+            Self::Markdown => 'M',
+            Self::AgentGuidance => 'A',
+            Self::ClaudeMd => 'C',
+            Self::GitTrailers => 'G',
+        }
+    }
+
+    pub fn all() -> &'static [ExportFormat] {
+        &[
+            Self::Json,
+            Self::Markdown,
+            Self::AgentGuidance,
+            Self::ClaudeMd,
+            Self::GitTrailers,
+        ]
+    }
+}
 
 #[derive(Serialize)]
 pub struct FeedbackExport {
@@ -135,8 +177,8 @@ fn build_export(state: &AppState, target_label: &str) -> FeedbackExport {
                     old_range: ann.anchor.old_range,
                     new_range: ann.anchor.new_range,
                     comment: ann.comment.clone(),
-                    category: None, // Could be extended in the future
-                    severity: None, // Could be extended in the future
+                    category: Some(ann.category.label().to_string()),
+                    severity: Some(ann.severity.label().to_string()),
                 })
                 .collect()
         } else {
@@ -176,6 +218,437 @@ fn count_reviewed_files(state: &AppState) -> usize {
             matches!(state.review.status(&path), FileReviewStatus::Reviewed)
         })
         .count()
+}
+
+/// Export feedback in the specified format. Returns the file path for file-based
+/// formats, or the generated text for clipboard-based formats.
+pub fn export_with_format(
+    state: &AppState,
+    repo_path: &Path,
+    target_label: &str,
+    format: ExportFormat,
+) -> Result<ExportResult, String> {
+    match format {
+        ExportFormat::Json => {
+            let path = export_feedback(state, repo_path, target_label)?;
+            Ok(ExportResult::File(path))
+        }
+        ExportFormat::Markdown => {
+            let text = generate_markdown(state, target_label);
+            let path = write_export_file(repo_path, target_label, &text, "md")?;
+            Ok(ExportResult::File(path))
+        }
+        ExportFormat::AgentGuidance => {
+            let text = generate_agent_guidance(state, target_label);
+            Ok(ExportResult::Text(text))
+        }
+        ExportFormat::ClaudeMd => {
+            let text = generate_claude_md_patch(state, target_label);
+            Ok(ExportResult::Text(text))
+        }
+        ExportFormat::GitTrailers => {
+            let text = generate_git_trailers(state, target_label);
+            Ok(ExportResult::Text(text))
+        }
+    }
+}
+
+pub enum ExportResult {
+    File(PathBuf),
+    Text(String),
+}
+
+fn write_export_file(
+    repo_path: &Path,
+    target_label: &str,
+    content: &str,
+    extension: &str,
+) -> Result<PathBuf, String> {
+    let dir = repo_path.join(".mdiff-feedback");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create directory: {}", e))?;
+    let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
+    let filename = format!(
+        "feedback_{}_{}.{}",
+        target_label.replace(['/', '\\', ':', ' '], "_"),
+        timestamp,
+        extension,
+    );
+    let path = dir.join(&filename);
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))?;
+    Ok(path)
+}
+
+/// Structured annotation data used by the guidance generators.
+struct GuidanceAnnotation {
+    file_path: String,
+    line_ref: String,
+    comment: String,
+    category: AnnotationCategory,
+    severity: AnnotationSeverity,
+}
+
+fn collect_guidance_annotations(state: &AppState) -> Vec<GuidanceAnnotation> {
+    let mut out = Vec::new();
+    for ann in state.annotations.all_sorted() {
+        let line_ref = match (ann.anchor.old_range, ann.anchor.new_range) {
+            (_, Some((s, e))) if s == e => format!("{}:{}", ann.anchor.file_path, s),
+            (_, Some((s, e))) => format!("{}:{}-{}", ann.anchor.file_path, s, e),
+            (Some((s, e)), None) if s == e => {
+                format!("{} (removed line {})", ann.anchor.file_path, s)
+            }
+            (Some((s, e)), None) => {
+                format!("{} (removed lines {}-{})", ann.anchor.file_path, s, e)
+            }
+            (None, None) => ann.anchor.file_path.clone(),
+        };
+        out.push(GuidanceAnnotation {
+            file_path: ann.anchor.file_path.clone(),
+            line_ref,
+            comment: ann.comment.clone(),
+            category: ann.category,
+            severity: ann.severity,
+        });
+    }
+    out
+}
+
+/// Classify an annotation into a guidance section.
+enum GuidanceSection {
+    Critical,
+    Suggestion,
+    StyleNote,
+    Question,
+    Positive,
+}
+
+fn classify_annotation(ann: &GuidanceAnnotation, scores: &[(String, u8)]) -> GuidanceSection {
+    let has_positive_score = scores.iter().any(|(fp, s)| fp == &ann.file_path && *s >= 4);
+
+    if has_positive_score {
+        return GuidanceSection::Positive;
+    }
+
+    match ann.category {
+        AnnotationCategory::Question => GuidanceSection::Question,
+        AnnotationCategory::Bug | AnnotationCategory::Security => match ann.severity {
+            AnnotationSeverity::Critical | AnnotationSeverity::Major => GuidanceSection::Critical,
+            _ => GuidanceSection::Suggestion,
+        },
+        AnnotationCategory::Performance => match ann.severity {
+            AnnotationSeverity::Critical | AnnotationSeverity::Major => GuidanceSection::Critical,
+            _ => GuidanceSection::Suggestion,
+        },
+        AnnotationCategory::Style | AnnotationCategory::Nitpick => GuidanceSection::StyleNote,
+        AnnotationCategory::Suggestion => match ann.severity {
+            AnnotationSeverity::Critical => GuidanceSection::Critical,
+            _ => GuidanceSection::Suggestion,
+        },
+    }
+}
+
+fn collect_file_scores(state: &AppState) -> Vec<(String, u8)> {
+    state
+        .annotations
+        .all_scores_sorted()
+        .iter()
+        .map(|s| (s.file_path.clone(), s.score))
+        .collect()
+}
+
+/// Generate the Agent Instruction Format (direct prompt for agents).
+pub fn generate_agent_guidance(state: &AppState, target_label: &str) -> String {
+    let annotations = collect_guidance_annotations(state);
+    if annotations.is_empty() {
+        return "No annotations to export.".to_string();
+    }
+
+    let scores = collect_file_scores(state);
+
+    let mut critical = Vec::new();
+    let mut suggestions = Vec::new();
+    let mut style_notes = Vec::new();
+    let mut questions = Vec::new();
+    let mut positive = Vec::new();
+
+    for ann in &annotations {
+        match classify_annotation(ann, &scores) {
+            GuidanceSection::Critical => critical.push(ann),
+            GuidanceSection::Suggestion => suggestions.push(ann),
+            GuidanceSection::StyleNote => style_notes.push(ann),
+            GuidanceSection::Question => questions.push(ann),
+            GuidanceSection::Positive => positive.push(ann),
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "I reviewed your changes in {}. Here is my structured feedback:\n",
+        target_label
+    ));
+
+    let mut item_num = 1u32;
+
+    if !critical.is_empty() {
+        out.push_str("\n## Critical Issues (must fix)\n");
+        for ann in &critical {
+            let cat_label = ann.category.label().to_uppercase();
+            out.push_str(&format!(
+                "{}. [{}] {}: {}\n",
+                item_num, ann.line_ref, cat_label, ann.comment
+            ));
+            item_num += 1;
+        }
+    }
+
+    if !suggestions.is_empty() {
+        out.push_str("\n## Suggestions (should fix)\n");
+        for ann in &suggestions {
+            let cat_label = ann.category.label().to_uppercase();
+            out.push_str(&format!(
+                "{}. [{}] {}: {}\n",
+                item_num, ann.line_ref, cat_label, ann.comment
+            ));
+            item_num += 1;
+        }
+    }
+
+    if !style_notes.is_empty() {
+        out.push_str("\n## Style Notes (low priority)\n");
+        for ann in &style_notes {
+            out.push_str(&format!(
+                "{}. [{}] {}\n",
+                item_num, ann.line_ref, ann.comment
+            ));
+            item_num += 1;
+        }
+    }
+
+    if !questions.is_empty() {
+        out.push_str("\n## Questions for Clarification\n");
+        for ann in &questions {
+            out.push_str(&format!(
+                "{}. [{}] {}\n",
+                item_num, ann.line_ref, ann.comment
+            ));
+            item_num += 1;
+        }
+    }
+
+    if !positive.is_empty() {
+        out.push_str("\n## Positive Observations (keep doing)\n");
+        for ann in &positive {
+            out.push_str(&format!(
+                "{}. [{}] {}\n",
+                item_num, ann.line_ref, ann.comment
+            ));
+            item_num += 1;
+        }
+    }
+
+    let last_item = item_num - 1;
+    if !critical.is_empty() {
+        let crit_max = critical.len() as u32;
+        out.push_str(&format!(
+            "\nPlease address items 1-{} as critical fixes",
+            crit_max
+        ));
+        if !suggestions.is_empty() {
+            out.push_str(&format!(
+                ", then items {}-{} as improvements",
+                crit_max + 1,
+                crit_max + suggestions.len() as u32
+            ));
+        }
+        out.push('.');
+    }
+    if !positive.is_empty() {
+        out.push_str(&format!(
+            " Do not change the patterns noted in item{}{}.\n",
+            if positive.len() > 1 { "s " } else { " " },
+            (last_item - positive.len() as u32 + 1..=last_item)
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    } else {
+        out.push('\n');
+    }
+
+    let char_count = out.len();
+    let approx_tokens = char_count / 4;
+    if approx_tokens > 4000 {
+        out.push_str(&format!(
+            "\n⚠ Warning: This guidance is approximately {} tokens. Consider splitting into smaller chunks.\n",
+            approx_tokens
+        ));
+    }
+
+    out
+}
+
+/// Generate CLAUDE.md / AGENTS.md patch format.
+pub fn generate_claude_md_patch(state: &AppState, target_label: &str) -> String {
+    let annotations = collect_guidance_annotations(state);
+    if annotations.is_empty() {
+        return "No annotations to export.".to_string();
+    }
+
+    let scores = collect_file_scores(state);
+
+    let mut avoid = Vec::new();
+    let mut follow = Vec::new();
+    let mut fixes = Vec::new();
+
+    for ann in &annotations {
+        match classify_annotation(ann, &scores) {
+            GuidanceSection::Critical | GuidanceSection::Suggestion => {
+                // Annotations with specific line ranges go to fixes, others to avoid
+                if ann.line_ref.contains(':') {
+                    fixes.push(ann);
+                }
+                avoid.push(ann);
+            }
+            GuidanceSection::Positive => follow.push(ann),
+            GuidanceSection::StyleNote => avoid.push(ann),
+            GuidanceSection::Question => {}
+        }
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "## Review Feedback (from mdiff review of {})\n",
+        target_label
+    ));
+
+    if !avoid.is_empty() {
+        out.push_str("\n### Patterns to Avoid\n");
+        for ann in &avoid {
+            let sev_label = ann.severity.label().to_lowercase();
+            let cat_label = ann.category.label().to_lowercase();
+            out.push_str(&format!(
+                "- In `{}`: {} (Severity: {}, Category: {})\n",
+                ann.file_path, ann.comment, sev_label, cat_label
+            ));
+        }
+    }
+
+    if !follow.is_empty() {
+        out.push_str("\n### Patterns to Follow\n");
+        for ann in &follow {
+            out.push_str(&format!("- In `{}`: {}\n", ann.file_path, ann.comment));
+        }
+    }
+
+    if !fixes.is_empty() {
+        out.push_str("\n### Specific Fixes Required\n");
+        for ann in &fixes {
+            out.push_str(&format!("- `{}`: {}\n", ann.line_ref, ann.comment));
+        }
+    }
+
+    out
+}
+
+/// Generate Git Trailer format.
+pub fn generate_git_trailers(state: &AppState, target_label: &str) -> String {
+    let annotations = collect_guidance_annotations(state);
+    if annotations.is_empty() {
+        return "No annotations to export.".to_string();
+    }
+
+    let scores = collect_file_scores(state);
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Reviewed-by: reviewer via mdiff ({})\n",
+        target_label
+    ));
+
+    let total_scores: Vec<u8> = scores.iter().map(|(_, s)| *s).collect();
+    if !total_scores.is_empty() {
+        let avg = total_scores.iter().map(|s| *s as f64).sum::<f64>() / total_scores.len() as f64;
+        out.push_str(&format!("Review-score: {:.0}/5\n", avg));
+    }
+
+    for ann in &annotations {
+        match classify_annotation(ann, &scores) {
+            GuidanceSection::Critical => {
+                let short_comment = truncate_for_trailer(&ann.comment);
+                out.push_str(&format!(
+                    "Review-critical: {} {}\n",
+                    ann.line_ref, short_comment
+                ));
+            }
+            GuidanceSection::Suggestion | GuidanceSection::StyleNote => {
+                let short_comment = truncate_for_trailer(&ann.comment);
+                out.push_str(&format!(
+                    "Review-suggestion: {} {}\n",
+                    ann.line_ref, short_comment
+                ));
+            }
+            GuidanceSection::Positive => {
+                let short_comment = truncate_for_trailer(&ann.comment);
+                out.push_str(&format!(
+                    "Review-approved: {} {}\n",
+                    ann.line_ref, short_comment
+                ));
+            }
+            GuidanceSection::Question => {
+                let short_comment = truncate_for_trailer(&ann.comment);
+                out.push_str(&format!(
+                    "Review-question: {} {}\n",
+                    ann.line_ref, short_comment
+                ));
+            }
+        }
+    }
+
+    out
+}
+
+fn truncate_for_trailer(s: &str) -> String {
+    let first_line = s.lines().next().unwrap_or(s);
+    if first_line.len() > 72 {
+        format!("{}...", &first_line[..69])
+    } else {
+        first_line.to_string()
+    }
+}
+
+/// Generate a basic Markdown export of annotations.
+fn generate_markdown(state: &AppState, target_label: &str) -> String {
+    let export = build_export(state, target_label);
+    let mut out = String::new();
+    out.push_str(&format!("# Feedback for {}\n\n", target_label));
+    out.push_str(&format!("*Exported at {}*\n\n", export.exported_at));
+    out.push_str(&format!(
+        "**Summary**: {} files, {} reviewed, {} annotations\n\n",
+        export.summary.total_files, export.summary.files_reviewed, export.summary.total_annotations,
+    ));
+
+    for file in &export.files {
+        if file.annotations.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("## `{}`\n\n", file.path));
+        out.push_str(&format!(
+            "+{} / -{} | Status: {}\n\n",
+            file.additions, file.deletions, file.review_status
+        ));
+        for ann in &file.annotations {
+            let range = match (ann.old_range, ann.new_range) {
+                (_, Some((s, e))) if s == e => format!("Line {}", s),
+                (_, Some((s, e))) => format!("Lines {}-{}", s, e),
+                (Some((s, e)), None) if s == e => format!("Removed line {}", s),
+                (Some((s, e)), None) => format!("Removed lines {}-{}", s, e),
+                (None, None) => "Unknown range".to_string(),
+            };
+            out.push_str(&format!("- **{}**: {}\n", range, ann.comment));
+        }
+        out.push('\n');
+    }
+
+    out
 }
 
 /// Ensure `.mdiff-feedback/` is listed in `.gitignore`.
@@ -258,5 +731,149 @@ mod tests {
         assert!(!export.exported_at.is_empty());
         assert_eq!(export.summary.total_files, 0); // No deltas in empty state
         assert!(export.files.is_empty());
+    }
+
+    fn state_with_annotations() -> AppState {
+        use crate::state::annotation_state::{
+            Annotation, AnnotationCategory, AnnotationSeverity, LineAnchor,
+        };
+        let diff_options = DiffOptions::new(false, false);
+        let theme = Theme::from_name("one-dark");
+        let mut state = AppState::new(diff_options, theme);
+        state.target_label = "main".to_string();
+
+        state.annotations.add(Annotation {
+            anchor: LineAnchor {
+                file_path: "src/handler.rs".to_string(),
+                old_range: None,
+                new_range: Some((45, 52)),
+            },
+            comment: "unwrap() on user input will panic".to_string(),
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            category: AnnotationCategory::Bug,
+            severity: AnnotationSeverity::Critical,
+        });
+
+        state.annotations.add(Annotation {
+            anchor: LineAnchor {
+                file_path: "src/db.rs".to_string(),
+                old_range: None,
+                new_range: Some((30, 45)),
+            },
+            comment: "N+1 query in user loading loop".to_string(),
+            created_at: "2025-01-01T00:00:01Z".to_string(),
+            category: AnnotationCategory::Performance,
+            severity: AnnotationSeverity::Major,
+        });
+
+        state.annotations.add(Annotation {
+            anchor: LineAnchor {
+                file_path: "src/handler.rs".to_string(),
+                old_range: None,
+                new_range: Some((80, 80)),
+            },
+            comment: "Function exceeds 50 lines".to_string(),
+            created_at: "2025-01-01T00:00:02Z".to_string(),
+            category: AnnotationCategory::Style,
+            severity: AnnotationSeverity::Minor,
+        });
+
+        state.annotations.add(Annotation {
+            anchor: LineAnchor {
+                file_path: "src/auth.rs".to_string(),
+                old_range: None,
+                new_range: Some((10, 10)),
+            },
+            comment: "Why is this endpoint public?".to_string(),
+            created_at: "2025-01-01T00:00:03Z".to_string(),
+            category: AnnotationCategory::Question,
+            severity: AnnotationSeverity::Info,
+        });
+
+        state
+    }
+
+    #[test]
+    fn test_agent_guidance_no_annotations() {
+        let diff_options = DiffOptions::new(false, false);
+        let theme = Theme::from_name("one-dark");
+        let state = AppState::new(diff_options, theme);
+        let result = generate_agent_guidance(&state, "HEAD");
+        assert_eq!(result, "No annotations to export.");
+    }
+
+    #[test]
+    fn test_agent_guidance_with_annotations() {
+        let state = state_with_annotations();
+        let result = generate_agent_guidance(&state, "main");
+
+        assert!(result.contains("I reviewed your changes in main"));
+        assert!(result.contains("## Critical Issues (must fix)"));
+        assert!(result.contains("unwrap()"));
+        assert!(result.contains("N+1 query"));
+        assert!(result.contains("## Style Notes (low priority)"));
+        assert!(result.contains("Function exceeds 50 lines"));
+        assert!(result.contains("## Questions for Clarification"));
+        assert!(result.contains("Why is this endpoint public?"));
+    }
+
+    #[test]
+    fn test_claude_md_patch_with_annotations() {
+        let state = state_with_annotations();
+        let result = generate_claude_md_patch(&state, "main");
+
+        assert!(result.contains("## Review Feedback (from mdiff review of main)"));
+        assert!(result.contains("### Patterns to Avoid"));
+        assert!(result.contains("unwrap()"));
+        assert!(result.contains("### Specific Fixes Required"));
+    }
+
+    #[test]
+    fn test_git_trailers_with_annotations() {
+        let state = state_with_annotations();
+        let result = generate_git_trailers(&state, "main");
+
+        assert!(result.contains("Reviewed-by: reviewer via mdiff (main)"));
+        assert!(result.contains("Review-critical:"));
+        assert!(result.contains("Review-suggestion:"));
+        assert!(result.contains("Review-question:"));
+    }
+
+    #[test]
+    fn test_claude_md_patch_no_annotations() {
+        let diff_options = DiffOptions::new(false, false);
+        let theme = Theme::from_name("one-dark");
+        let state = AppState::new(diff_options, theme);
+        let result = generate_claude_md_patch(&state, "HEAD");
+        assert_eq!(result, "No annotations to export.");
+    }
+
+    #[test]
+    fn test_git_trailers_no_annotations() {
+        let diff_options = DiffOptions::new(false, false);
+        let theme = Theme::from_name("one-dark");
+        let state = AppState::new(diff_options, theme);
+        let result = generate_git_trailers(&state, "HEAD");
+        assert_eq!(result, "No annotations to export.");
+    }
+
+    #[test]
+    fn test_truncate_for_trailer_short() {
+        assert_eq!(truncate_for_trailer("short text"), "short text");
+    }
+
+    #[test]
+    fn test_truncate_for_trailer_long() {
+        let long = "a".repeat(100);
+        let result = truncate_for_trailer(&long);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 72 + 3);
+    }
+
+    #[test]
+    fn test_export_format_enum() {
+        assert_eq!(ExportFormat::Json.label(), "JSON");
+        assert_eq!(ExportFormat::AgentGuidance.shortcut(), 'A');
+        assert_eq!(ExportFormat::all().len(), 5);
     }
 }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -138,6 +138,9 @@ pub struct AppState {
     // Feedback summary
     pub feedback_summary_scroll: usize,
 
+    // Export format picker
+    pub export_format_picker_open: bool,
+
     // Checklist
     pub checklist: ChecklistState,
 }
@@ -181,6 +184,7 @@ impl AppState {
             settings: SettingsState::default(),
             global_search: GlobalSearchState::default(),
             feedback_summary_scroll: 0,
+            export_format_picker_open: false,
             which_key_visible: false,
             checklist: ChecklistState::new(),
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User Problem
mdiff exports annotations as JSON and markdown designed for human consumption, but coding agents need differently structured feedback to improve. Currently, after reviewing agent output and adding detailed annotations with categories, severities, and suggestions, the reviewer must manually reformat their feedback into agent-consumable instructions. This breaks the feedback loop — the structured data exists in mdiff but can't flow back to agents efficiently. Research from Scale Labs' Agent-RLVR framework shows structured guidance improves agent success rates by 2-3x.

## Planned Approach
Extend the existing `Ctrl+E` export system with three new format options: (1) Agent Instruction Format — a structured prompt that can be pasted directly into Claude Code, Codex, or Cursor with critical issues, suggestions, and positive observations organized by priority; (2) CLAUDE.md Patch Format — generates a section for the project's CLAUDE.md/AGENTS.md with patterns to avoid, patterns to follow, and specific fixes; (3) Git Trailer Format — structured trailers for commit messages. Add an `ExportFormat` enum, format picker UI component, and annotation-to-guidance mapping logic that converts mdiff's categories/severities into priority-based guidance sections.

## User Benefit
Closes the human-in-the-loop feedback cycle: agent produces code → reviewer annotates in mdiff → export generates agent guidance → agent consumes guidance → better code. Transforms mdiff from a review viewer into a review feedback system. The reviewer's annotations become actionable instructions without manual reformatting.

## Visual Preview
[Visual mockup will be added by the ideation agent]

## Spec Reference
See `.github/specs/027-agent-guidance-export.md`

## Changes

### New files
- `src/components/export_picker.rs` — Format picker overlay UI component

### Modified files
- `src/export.rs` — `ExportFormat` enum, `export_with_format()`, `generate_agent_guidance()`, `generate_claude_md_patch()`, `generate_git_trailers()`, `generate_markdown()`, plus 9 new tests
- `src/action.rs` — `OpenExportFormatPicker`, `SelectExportFormat(ExportFormat)`, `CancelExportFormatPicker` action variants
- `src/state/app_state.rs` — `export_format_picker_open` field on `AppState`
- `src/event.rs` — Format picker keybindings (`J/M/A/C/G/Esc`), `Ctrl+E` now opens picker
- `src/app.rs` — Action handlers for format picker open/select/cancel, overlay rendering, clipboard/file export dispatch
- `src/components/mod.rs` — Register `export_picker` module
- `src/components/which_key.rs` — Updated `Ctrl+E` description to "Export (format picker)"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89603837-be67-46c8-b704-73898bf27a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89603837-be67-46c8-b704-73898bf27a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

