### PR TITLE
chore: release v0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/MutinyHQ/mdiff/compare/v0.1.22...v0.1.23) - 2026-03-31
+
+### Fixed
+
+- add boundary padding rows and fix scroll clipping at bottom
+- keymapping consistency
+
+### Other
+
+- Merge branch 'main' into feat/diff-statistics-dashboard-019
+- Merge pull request #77 from MutinyHQ/cursor/diff-timeline-scrubber-9c30
+- add spec 035 — Fix Diff Scroll Bottom & Boundary Padding (Issue #25, second pass)
+- update ROADMAP.md and journal for Run #14 (2026-03-27)
+- add spec 034 — Inline Diff Minimap
+- add spec 032 — Automated Review Surface (Issue #71)
+- add spec 033 — Diff Timeline Scrubber
+
 ## [0.1.22](https://github.com/MutinyHQ/mdiff/compare/v0.1.21...v0.1.22) - 2026-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "mutiny-diff"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutiny-diff"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "TUI git diff viewer with worktree management"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mutiny-diff`: 0.1.22 -> 0.1.23

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.23](https://github.com/MutinyHQ/mdiff/compare/v0.1.22...v0.1.23) - 2026-03-31

### Fixed

- add boundary padding rows and fix scroll clipping at bottom
- keymapping consistency

### Other

- Merge branch 'main' into feat/diff-statistics-dashboard-019
- Merge pull request #77 from MutinyHQ/cursor/diff-timeline-scrubber-9c30
- add spec 035 — Fix Diff Scroll Bottom & Boundary Padding (Issue #25, second pass)
- update ROADMAP.md and journal for Run #14 (2026-03-27)
- add spec 034 — Inline Diff Minimap
- add spec 032 — Automated Review Surface (Issue #71)
- add spec 033 — Diff Timeline Scrubber
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).