### PR TITLE
docs: update ROADMAP.md and journal for Run #14 (2026-03-27)

### DIFF
--- a/.github/journal.md
+++ b/.github/journal.md
@@ -1,5 +1,61 @@
 # mdiff Ideation Agent Journal
 
+## 2026-03-27 (Run #14)
+
+### Research Findings
+- **vibetracer v0.5.0** (Rust, MIT): New TUI tool that records AI coding assistant edits as diffs and lets users scrub through a timeline to inspect and surgically restore changes. Cross-agent tracing (Claude Code, Cursor, Codex CLI). Directly overlapping with mdiff's focus — inspired the Diff Timeline Scrubber feature.
+- **Reddit r/opencodeCLI** (2026-03-26): Developer explicitly wants terminal-native side-by-side diff viewer for reviewing/editing agent code, rejects Cursor and Neovim. Strong validation for mdiff's value proposition.
+- **Cursor real-time RL** (blog post): Cursor uses implicit user actions (accept/reject/edit) as reward signals, shipping improved models every 5 hours. Low-friction feedback capture is more valuable than elaborate annotation forms — validates mdiff's quick-reaction scoring approach.
+- **Scale AI Online Rubrics**: Dynamically evolving evaluation criteria outperform static rubrics by up to 8%. Relevant for future custom review rubric evolution.
+- **Claude Code Review**: Severity-ranked inline diff annotations with summary comments from multi-agent review. Adaptive review depth based on PR size. Reference architecture for the Automated Review Surface.
+- **HN discussion "slowing the fuck down"** (1074 points, 473 comments): Growing concern about AI codebases being incomprehensible to humans. Validates structured review tools.
+- **OpenClaw TUI**: Terminal AI agent with slash commands, compared alongside Claude Code and OpenCode as competing terminal-based AI developer tools.
+
+### Open Issues Review
+| Issue | Category | Priority | Assessment |
+|-------|----------|----------|------------|
+| #71 (Automated review) | Feature | P1 | **SELECTED** for implementation. Spec 032 written, Cursor agent launched. |
+| #70 (Agentic review mode) | Feature | P1 | Already implemented on main. Foundation for #71. |
+| #64 (Tree file viewer) | Bug | P0 | PR #72 from previous cycle agent. Under review. |
+| #52 (Ask a Question) | Feature | P1 | Spec 021 exists. Deferred to next cycle in favor of #71. |
+| #25 (Diff line calculations) | Bug | P0 | Fix merged (PR #50) but issue still open. Should be closed. |
+
+### Ideas Evaluated
+| Idea | Source | Priority | Action |
+|------|--------|----------|--------|
+| Automated Review Surface | Issue #71 | P1 | **SPEC 032** written, Cursor agent launched |
+| Diff Timeline Scrubber | vibetracer research | P1 | **SPEC 033** written, Cursor agent launched |
+| Inline Diff Minimap | Promoted from P2 | P1 | **SPEC 034** written, Cursor agent launched |
+| Implicit Feedback Signals | Cursor RL research | Deferred | Requires deeper design work |
+| Dynamic Review Rubrics | Scale AI research | P3 candidate | Extends Custom Review Rubric concept |
+| Adaptive Review Depth | Claude Code Review | Deferred | Overlaps with Diff Rendering Quality Indicators |
+
+### Specs Written
+1. `.github/specs/032-automated-review-surface.md` — Navigable AI findings panel with accept/dismiss/edit (Issue #71)
+2. `.github/specs/033-diff-timeline-scrubber.md` — Commit timeline scrubber with per-commit diff isolation
+3. `.github/specs/034-inline-diff-minimap.md` — Vertical minimap on right edge of diff view
+
+### PRs & Agents
+**Open PRs reviewed:** PR #75 (release), PR #72 (tree view +142/-6), PR #69 (go-to-line +736/-5), PR #67 (file preview +35/-16), PR #62 (attribution +747/-21), PR #61 (guidance export, draft), PR #55 (suggestions +910/-76)
+
+**Cursor agents launched:** bc-6072366f (Automated Review Surface), bc-b42db32f (Diff Timeline Scrubber), bc-22d8e88a (Inline Diff Minimap)
+
+### PR Review Notes
+- PR #55 (Suggestions): **Issue found** — app_state.rs has duplicate import blocks that will cause compilation errors.
+- PR #72 (Tree View): Solid implementation matching spec 029.
+- PR #69 (Go-to-Line/Picker): Comprehensive, follows existing patterns well.
+- PR #67 (File Preview): Minimal and correct fix.
+- PR #62 (Attribution): Well-structured with proper git commit analysis.
+
+### Competitive Landscape Updates
+- Added **vibetracer** (Rust, timeline-based AI edit replay)
+- Added **OpenClaw TUI** (terminal AI agent)
+
+### Visual Mockups Generated
+- Automated Review Surface: https://www.town.com/content/image/sd70e07fhaa5jdqytsgebr20x183pt36
+- Diff Timeline Scrubber: https://www.town.com/content/image/sd7f3texkwzkeb78f1tqg4ydd583pcqh
+- Inline Diff Minimap: https://www.town.com/content/image/sd7bym80nkgjvmhmvf1md5yg2183qkvh
+
 ## 2026-03-23 (Run #12)
 
 ### Research Findings

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,10 @@
 # mdiff Roadmap & Feature Backlog
 
 > **Maintained by**: Milo (automated ideation agent)
-> **Last updated**: 2026-03-24
+> **Last updated**: 2026-03-27
 > **Schedule**: New ideas are evaluated and prioritized every 24 hours
 
-This document tracks feature ideas, prioritized issues, and the rationale behind them. It draws from competitive analysis of tools like **critique**, **tuicr**, **acre**, **difi**, **deff**, **git-review**, **Kaleidoscope**, **lazygit**, **fzf**, **justshowmediff**, **IPE**, **diffreview**, **Fresh**, **1Code**, **Duff**, **patchcast**, **Anduin**, **carn**, **ftdv**, **keifu**, **dead-ringer**, **cmux**, **Muse/Manyana**, **oh-my-pi**, **Superset**, **Orchestrator**, and patterns from RLHF/human feedback research.
+This document tracks feature ideas, prioritized issues, and the rationale behind them. It draws from competitive analysis of tools like **critique**, **tuicr**, **acre**, **difi**, **deff**, **git-review**, **Kaleidoscope**, **lazygit**, **fzf**, **justshowmediff**, **IPE**, **diffreview**, **Fresh**, **1Code**, **Duff**, **patchcast**, **Anduin**, **carn**, **ftdv**, **keifu**, **dead-ringer**, **cmux**, **Muse/Manyana**, **oh-my-pi**, **Superset**, **Orchestrator**, **vibetracer**, **OpenClaw**, and patterns from RLHF/human feedback research.
 
 ---
 
@@ -131,6 +131,25 @@ This document tracks feature ideas, prioritized issues, and the rationale behind
 **Rationale**: mdiff exports annotations as JSON/markdown for humans, but agents need differently structured feedback. Agent-RLVR research shows structured guidance improves agent success 2-3x. New export formats: Agent Instruction prompt, CLAUDE.md patch, and Git trailers.
 **Scope**: Three new export formats in Ctrl+E dialog. Annotation-to-guidance mapping. Format picker UI.
 
+#### Automated Review Surface (Issue #71)
+**Status**: Spec written (032), Cursor agent launched (2026-03-27)
+**Addresses**: GitHub Issue #71
+**Rationale**: After #70 landed agentic review mode on main, AI-generated findings stream as raw text into a side panel with no structured navigation. Users need to triage AI findings at keyboard speed — accept good ones as annotations, dismiss false positives, edit imprecise suggestions. This is the missing link between AI-generated analysis and mdiff's structured annotation system. Directly requested by repo owner in Issue #71.
+**Scope**: AutoReviewState with ReviewFinding entries, auto-review panel component, accept/dismiss/edit/jump-to-code actions, filter cycling, finding count summary. Builds on existing AgenticReviewComplete action.
+**Competitive reference**: Claude Code Review severity-ranked findings, Cursor's accept/reject implicit feedback pattern.
+
+#### Diff Timeline Scrubber (NEW)
+**Status**: Spec written (033), Cursor agent launched (2026-03-27)
+**Rationale**: Coding agents produce multiple commits per session — iterating on code, fixing errors, adding tests. The final diff flattens all iterations, making it impossible to understand the agent's reasoning process. vibetracer (Rust, released March 2026) validates this pattern with timeline-based diff replay. mdiff's existing attribution system maps hunks to commits; the timeline scrubber extends this by allowing users to isolate individual commits and see the diff at each step.
+**Scope**: TimelineState, horizontal timeline bar component, commit scrubbing with < and > keys, single-commit diff computation (parent..commit), combined diff caching, navigator file list filtering per commit.
+**Competitive reference**: vibetracer (Rust crate for AI edit timeline replay), git-time-machine (TUI reflog navigation).
+
+#### Inline Diff Minimap (Promoted from P2)
+**Status**: Spec written (034), Cursor agent launched (2026-03-27)
+**Rationale**: When reviewing large files (500+ lines) modified by coding agents, reviewers lose orientation. VS Code's minimap is one of its most-used navigation features. No TUI diff viewer currently offers this. Promoted from P2 based on growing file sizes in agent output and validation from competitive landscape (patchcast, VS Code).
+**Scope**: 3-column vertical minimap on right edge of diff view, color-coded by change type (green/red/yellow), current viewport indicator, density calculation from display map, M key toggle.
+**Competitive reference**: VS Code minimap, patchcast visual diff approach.
+
 ---
 
 ### P2 — Nice to Have
@@ -158,7 +177,7 @@ This document tracks feature ideas, prioritized issues, and the rationale behind
 **Rationale**: Color-code regions by change density for quick visual scanning.
 
 #### Inline Diff Minimap
-**Status**: NEW (2026-03-17)
+**Status**: **Promoted to P1** (2026-03-27)
 **Rationale**: Vertical minimap on the right edge of the diff view showing change density across the file. Color-coded bar indicating add/delete regions for quick visual orientation. Inspired by VS Code's minimap and patchcast's visual diff approach. Helps reviewers understand where changes are concentrated without scrolling.
 **Scope**: Render a narrow column (2-3 chars wide) on the right edge of the diff view. Map each row to a proportional section of the file. Color green for additions, red for deletions, dim for context. Highlight current viewport position.
 
@@ -278,9 +297,11 @@ This document tracks feature ideas, prioritized issues, and the rationale behind
 
 | Issue | Category | Priority | Status | Action |
 |-------|----------|----------|--------|--------|
-| #65 | Bug | P0 | Open | **NEW** — Spec 030 written, Cursor agent launched (2026-03-24). File preview on hover broken in tree view. |
-| #64 | Bug | P0 | Open | **NEW** — Spec 029 written, Cursor agent launched (2026-03-24). Tree view has 5 inconsistencies. |
-| #63 | UX | P1 | Open | **NEW** — Spec 031 written, Cursor agent launched (2026-03-24). Go-to-line and fuzzy file picker. |
+| #71 | Feature | P1 | Open | **NEW** — Spec 032 written, Cursor agent launched (2026-03-27). Automated review surface for AI findings. |
+| #70 | Feature | P1 | Open — Implemented on main | Agentic review mode landed. Foundation for #71. |
+| #65 | Bug | P0 | Open | Spec 030 written, Cursor agent finished (2026-03-24). PR #67 open. File preview on hover broken in tree view. |
+| #64 | Bug | P0 | Open | Spec 029 written, Cursor agent finished (2026-03-24). PR #72 open. Tree view has 5 inconsistencies. |
+| #63 | UX | P1 | Open | Spec 031 written, Cursor agent finished (2026-03-24). PR #69 open. Go-to-line and fuzzy file picker. |
 | #53 | Feature | P1 | Open — PR #56 merged (2026-03-20) | **Implemented** — File Tree Navigator merged. Issue should be closed. |
 | #52 | Feature | P1 | Open | Spec 021 written, Cursor agent finished but no PR. Needs re-launch. |
 | #37 | Feature | P1 | Open (PR #45 merged, issue not closed) | Implementation complete, issue should be closed |
@@ -327,6 +348,8 @@ This document tracks feature ideas, prioritized issues, and the rationale behind
 - **fzf**: Gold standard for fuzzy search UX in terminals.
 - **jjui**: TUI for jujutsu (jj), panel-based keyboard-driven paradigm.
 - **gstack** (CLI): Garry Tan's open-source Claude Code toolkit with dedicated `/review` mode for production risk assessment and code review.
+- **vibetracer** (Rust): TUI tool for tracing and replaying AI coding assistant edits with timeline-based diff viewer. Cross-agent tracing for Claude Code, Cursor, Codex CLI. Exports to git-compatible formats. Direct overlap with mdiff's focus on agent diff review.
+- **OpenClaw TUI**: Terminal AI agent with slash commands and shortcuts. Compared alongside Claude Code and OpenCode as competing terminal-based AI developer tools.
 
 ### Key Market Gap
 No tool combines all three: (1) TUI-native diff review, (2) structured human feedback collection, (3) direct integration with coding agents. mdiff is uniquely positioned here.
@@ -423,6 +446,14 @@ A commenter on the Deff HN thread explicitly requested a TUI diff tool with the 
 - **Rich Feedback RL**: Field converging from scalar reward RL toward critiques, comparisons, checklists, verifier signals.
 - **git-time-machine** (Rust/ratatui): New TUI tool for visual git reflog navigation with vim keybindings.
 - **GitHub trending March 2026**: Dominated by AI agent frameworks, no TUI/diff tools in top trending — mdiff occupies a niche with growing demand.
+
+### Implicit Feedback & Timeline Patterns (from 2026-03-27 research)
+- **Cursor real-time RL**: Uses implicit user actions (accept/reject/edit) from production coding sessions as reward signals, shipping improved models every 5 hours. Low-friction feedback capture more valuable than elaborate forms. Validates mdiff's quick-reaction scoring approach.
+- **Scale AI Online Rubrics**: Dynamically generated evaluation criteria from pairwise comparisons outperform static rubrics by 8%. Model for evolving annotation schemas.
+- **vibetracer (Rust)**: Timeline-based scrubbing through AI agent edit history. Cross-agent tracing. Validates the Diff Timeline Scrubber feature.
+- **Reddit r/opencodeCLI**: Terminal-only developer explicitly requesting TUI side-by-side diff viewer for reviewing agent output. Rejects Cursor and Neovim. Direct validation of mdiff's value proposition.
+- **HN "slowing the fuck down" (1074 points)**: Growing concern about AI codebases being incomprehensible. Developer review tooling is essential infrastructure, not optional.
+- **Claude Code Review adaptive depth**: Scales review intensity with PR size — lightweight for <50 lines, deeper multi-agent for 1000+. Pattern for adaptive review guidance in mdiff.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates documentation for Run #14 of the ideation agent cycle (2026-03-27).

### Changes to `.github/journal.md`
- Added new Run #14 entry at the top of the journal with:
  - Research findings (vibetracer, Reddit r/opencodeCLI, Cursor real-time RL, Scale AI Online Rubrics, Claude Code Review, HN discussion, OpenClaw TUI)
  - Open issues review (5 issues assessed)
  - Ideas evaluated (6 ideas including 3 new specs)
  - Specs written (032, 033, 034)
  - PRs & agents reviewed/launched
  - PR review notes
  - Competitive landscape updates
  - Visual mockups

### Changes to `ROADMAP.md`
- Updated "Last updated" date to 2026-03-27
- Added **vibetracer** and **OpenClaw** to tracked tools in header
- Added 3 new P1 entries: Automated Review Surface (#71), Diff Timeline Scrubber, Inline Diff Minimap (promoted from P2)
- Updated Open Issues Triage table with #71 and #70, updated statuses for existing issues
- Added vibetracer and OpenClaw TUI to competitive tools section
- Added "Implicit Feedback & Timeline Patterns" research notes section
- Marked P2 Inline Diff Minimap as "Promoted to P1 (2026-03-27)"

**Note:** The user requested a direct commit to `main`, but branch protection rules require a PR. This PR should be merged to fulfill the request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1db0ebf-494d-4e6b-9fd3-08a88d8d6510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1db0ebf-494d-4e6b-9fd3-08a88d8d6510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

