### PR TITLE
feat: add diff timeline scrubber for commit-by-commit navigation

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -277,4 +277,10 @@ pub enum Action {
     AgenticReviewError(String),
     AgenticReviewPanelUp,
     AgenticReviewPanelDown,
+
+    // Timeline scrubber
+    ToggleTimeline,
+    TimelineNext,
+    TimelinePrev,
+    TimelineSelectAll,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ use crate::components::prompt_preview::render_prompt_preview;
 use crate::components::restore_confirm::render_restore_confirm;
 use crate::components::settings_modal::render_settings_modal;
 use crate::components::target_dialog::render_target_dialog;
+use crate::components::timeline_bar::render_timeline_bar;
 use crate::components::which_key;
 use crate::components::worktree_browser::WorktreeBrowser;
 use crate::components::Component;
@@ -246,7 +247,24 @@ impl App {
                         self.last_navigator_rect = main[0];
                         navigator.render(frame, main[0], &self.state);
 
-                        let diff_area = main[1];
+                        let diff_area_full = main[1];
+
+                        let timeline_h: u16 = if self.state.timeline.active
+                            && !self.state.timeline.commits.is_empty()
+                        {
+                            1
+                        } else {
+                            0
+                        };
+                        let (diff_area, timeline_area) = if timeline_h > 0 {
+                            let split = Layout::default()
+                                .direction(Direction::Vertical)
+                                .constraints([Constraint::Min(3), Constraint::Length(timeline_h)])
+                                .split(diff_area_full);
+                            (split[0], Some(split[1]))
+                        } else {
+                            (diff_area_full, None)
+                        };
 
                         if self.state.prompt_preview_visible {
                             let vsplit = Layout::default()
@@ -271,6 +289,10 @@ impl App {
                             self.last_diff_view_rect = diff_area;
                             self.update_diff_visual_metrics(diff_area);
                             diff_view.render(frame, diff_area, &self.state);
+                        }
+
+                        if let Some(tl_area) = timeline_area {
+                            render_timeline_bar(frame, tl_area, &self.state);
                         }
 
                         // Render right-side panels
@@ -390,6 +412,7 @@ impl App {
                     agentic_review_panel_open: self.state.agentic_review_panel_open,
                     agentic_review_composing: self.state.agentic_review_composing,
                     window_pending: self.window_pending,
+                    timeline_active: self.state.timeline.active,
                 };
                 let action = match event {
                     Event::Key(key) => {
@@ -941,7 +964,11 @@ impl App {
                 | Action::AgenticReviewPanelUp
                 | Action::AgenticReviewPanelDown
                 | Action::WindowPrefix
-                | Action::CycleFocus => {}
+                | Action::CycleFocus
+                | Action::ToggleTimeline
+                | Action::TimelineNext
+                | Action::TimelinePrev
+                | Action::TimelineSelectAll => {}
                 _ => {
                     self.state.hud_expanded = false;
                     self.hud_collapse_countdown = 0;
@@ -3078,6 +3105,44 @@ impl App {
                 self.state.agentic_review_scroll += 1;
                 // Don't re-enable auto_scroll — user is manually scrolling
             }
+
+            // Timeline scrubber actions
+            Action::ToggleTimeline => {
+                if self.state.timeline.active {
+                    // Deactivate: restore combined diff if we were filtering
+                    if self.state.timeline.selected_index.is_some() {
+                        self.restore_combined_diff();
+                    }
+                    self.state.timeline.active = false;
+                    self.state.timeline.selected_index = None;
+                } else {
+                    self.activate_timeline();
+                }
+            }
+            Action::TimelineNext => {
+                if self.state.timeline.active {
+                    let prev = self.state.timeline.selected_index;
+                    self.state.timeline.select_next();
+                    if self.state.timeline.selected_index != prev {
+                        self.apply_timeline_selection();
+                    }
+                }
+            }
+            Action::TimelinePrev => {
+                if self.state.timeline.active {
+                    let prev = self.state.timeline.selected_index;
+                    self.state.timeline.select_prev();
+                    if self.state.timeline.selected_index != prev {
+                        self.apply_timeline_selection();
+                    }
+                }
+            }
+            Action::TimelineSelectAll => {
+                if self.state.timeline.active && self.state.timeline.selected_index.is_some() {
+                    self.state.timeline.select_all();
+                    self.restore_combined_diff();
+                }
+            }
         }
     }
 
@@ -3095,6 +3160,95 @@ impl App {
             }
         }
         self.state.pty_focus = false;
+    }
+
+    fn activate_timeline(&mut self) {
+        let commits = crate::git::RepoCache::open(&self.repo_path)
+            .ok()
+            .and_then(|repo| {
+                crate::git::attribution::collect_timeline_commits(repo.repo(), &self.target).ok()
+            })
+            .unwrap_or_default();
+        if commits.is_empty() {
+            self.set_status_for_ticks("No commits found for timeline".into(), true, 60);
+            return;
+        }
+        self.state.timeline.cached_combined_deltas = self.state.diff.deltas.clone();
+        self.state.timeline.commits = commits;
+        self.state.timeline.selected_index = None;
+        self.state.timeline.active = true;
+        self.set_status_for_ticks(
+            format!(
+                "Timeline: {} commits (use </> to navigate, 0 for all)",
+                self.state.timeline.commits.len()
+            ),
+            false,
+            80,
+        );
+    }
+
+    fn apply_timeline_selection(&mut self) {
+        match self.state.timeline.selected_index {
+            None => {
+                self.restore_combined_diff();
+            }
+            Some(idx) => {
+                if let Some(commit) = self.state.timeline.commits.get(idx) {
+                    let oid = commit.oid.clone();
+                    match crate::git::RepoCache::open(&self.repo_path) {
+                        Ok(repo) => {
+                            match crate::git::DiffEngine::compute_commit_diff(
+                                repo.repo(),
+                                &oid,
+                                &self.state.diff.options,
+                            ) {
+                                Ok(deltas) => {
+                                    self.state.navigator.update_from_deltas(&deltas);
+                                    self.state.diff.deltas = deltas;
+                                    self.state.diff.selected_file =
+                                        if self.state.diff.deltas.is_empty() {
+                                            None
+                                        } else {
+                                            Some(0)
+                                        };
+                                    self.state.diff.scroll_offset = 0;
+                                    self.state.diff.cursor_row = 0;
+                                    self.update_highlights();
+                                }
+                                Err(e) => {
+                                    self.set_status_for_ticks(
+                                        format!("Failed to compute commit diff: {e}"),
+                                        true,
+                                        80,
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            self.set_status_for_ticks(
+                                format!("Failed to open repo: {e}"),
+                                true,
+                                80,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn restore_combined_diff(&mut self) {
+        let deltas = self.state.timeline.cached_combined_deltas.clone();
+        self.state.navigator.update_from_deltas(&deltas);
+        self.state.diff.deltas = deltas;
+        self.state.diff.selected_file = if self.state.diff.deltas.is_empty() {
+            None
+        } else {
+            Some(0)
+        };
+        self.state.diff.scroll_offset = 0;
+        self.state.diff.cursor_row = 0;
+        self.update_highlights();
     }
 
     fn active_text_buffer(&mut self) -> Option<&mut crate::state::TextBuffer> {

--- a/src/components/action_hud.rs
+++ b/src/components/action_hud.rs
@@ -349,6 +349,7 @@ mod tests {
             agentic_review_panel_open: state.agentic_review_panel_open,
             agentic_review_composing: state.agentic_review_composing,
             window_pending: false,
+            timeline_active: state.timeline.active,
         }
     }
 

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -97,6 +97,23 @@ fn format_title(delta: &FileDelta, view_label: &str, state: &AppState) -> String
             let after: String = q.chars().skip(ci).collect();
             format!("{base} /{}\u{2588}{}{match_info} ", before, after)
         }
+    } else if state.timeline.active && state.timeline.selected_index.is_some() {
+        let tl = &state.timeline;
+        let status = tl.status_text();
+        if let Some(idx) = tl.selected_index {
+            if let Some(c) = tl.commits.get(idx) {
+                let summary_trunc = if c.summary.len() > 50 {
+                    format!("{}…", &c.summary[..49])
+                } else {
+                    c.summary.clone()
+                };
+                format!("{base} {status} {summary_trunc} ")
+            } else {
+                format!("{base} {status} ")
+            }
+        } else {
+            format!("{base} {status} ")
+        }
     } else {
         format!("{base} ")
     }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -20,6 +20,7 @@ pub mod restore_confirm;
 pub mod settings_modal;
 pub mod target_dialog;
 pub mod text_input;
+pub mod timeline_bar;
 pub mod which_key;
 pub mod worktree_browser;
 

--- a/src/components/timeline_bar.rs
+++ b/src/components/timeline_bar.rs
@@ -1,0 +1,107 @@
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::state::AppState;
+use crate::theme::Theme;
+
+pub fn render_timeline_bar(frame: &mut Frame, area: Rect, state: &AppState) {
+    if !state.timeline.active || state.timeline.commits.is_empty() {
+        return;
+    }
+
+    let theme = &state.theme;
+    let commits = &state.timeline.commits;
+    let selected = state.timeline.selected_index;
+
+    let mut spans: Vec<Span> = Vec::new();
+
+    // "ALL" marker
+    let all_style = if selected.is_none() {
+        Style::default()
+            .fg(theme.surface)
+            .bg(theme.accent)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.text_muted)
+    };
+    spans.push(Span::styled(" ALL ", all_style));
+    spans.push(Span::raw(" "));
+
+    // Commit markers
+    let max_markers = (area.width as usize).saturating_sub(8) / 4;
+    let display_count = commits.len().min(max_markers);
+
+    for (i, _commit) in commits.iter().enumerate().take(display_count) {
+        let marker_style = if Some(i) == selected {
+            Style::default()
+                .fg(theme.surface)
+                .bg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.text_muted)
+        };
+
+        let label = format!("{}", i + 1);
+        spans.push(Span::styled(format!(" {label} "), marker_style));
+
+        if i + 1 < display_count {
+            spans.push(Span::styled("─", Style::default().fg(theme.text_muted)));
+        }
+    }
+
+    if commits.len() > max_markers {
+        spans.push(Span::styled(
+            format!(" +{}", commits.len() - max_markers),
+            Style::default().fg(theme.text_muted),
+        ));
+    }
+
+    // Info about selected commit
+    let info = match selected {
+        None => format!("  {} commits total", commits.len()),
+        Some(i) => {
+            let c = &commits[i];
+            let short_oid = if c.oid.len() >= 7 {
+                &c.oid[..7]
+            } else {
+                &c.oid
+            };
+            format!(
+                "  {} {} (+{}/-{} {}) {} by {}",
+                short_oid,
+                truncate_str(&c.summary, 40),
+                c.additions,
+                c.deletions,
+                if c.files_changed == 1 {
+                    "1 file".to_string()
+                } else {
+                    format!("{} files", c.files_changed)
+                },
+                c.timestamp,
+                c.author,
+            )
+        }
+    };
+    spans.push(Span::styled(info, Style::default().fg(theme.text)));
+
+    let line = Line::from(spans);
+    let bar = Paragraph::new(line).style(Style::default().bg(bar_bg(theme)));
+    frame.render_widget(bar, area);
+}
+
+fn bar_bg(theme: &Theme) -> ratatui::style::Color {
+    theme.surface
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max_len.saturating_sub(1)])
+    }
+}

--- a/src/components/which_key.rs
+++ b/src/components/which_key.rs
@@ -366,142 +366,177 @@ fn get_context_entries(state: &AppState) -> Vec<KeyEntry> {
                         description: "This help",
                     },
                     KeyEntry {
+                        key: "Ctrl+T",
+                        description: if state.timeline.active {
+                            "Hide timeline"
+                        } else {
+                            "Timeline"
+                        },
+                    },
+                    KeyEntry {
                         key: "Ctrl+C/D",
                         description: "Quit",
                     },
                 ]);
                 entries
             }
-            FocusPanel::DiffView => vec![
-                KeyEntry {
-                    key: "j/k",
-                    description: "Scroll",
-                },
-                KeyEntry {
-                    key: "g/G",
-                    description: "Top/bottom",
-                },
-                KeyEntry {
-                    key: "^W h/l",
-                    description: "Switch pane",
-                },
-                KeyEntry {
-                    key: "PgUp/Dn",
-                    description: "Page scroll",
-                },
-                KeyEntry {
-                    key: "Space",
-                    description: "Expand context",
-                },
-                KeyEntry {
-                    key: "e",
-                    description: "Open in $EDITOR",
-                },
-                KeyEntry {
-                    key: "/",
-                    description: "Search in diff",
-                },
-                KeyEntry {
-                    key: "n/N",
-                    description: "Next/prev match",
-                },
-                KeyEntry {
-                    key: "v",
-                    description: "Visual select",
-                },
-                KeyEntry {
-                    key: "i",
-                    description: "Add annotation",
-                },
-                KeyEntry {
-                    key: "a",
-                    description: "Annotation menu",
-                },
-                KeyEntry {
-                    key: "]",
-                    description: "Next hunk",
-                },
-                KeyEntry {
-                    key: "[",
-                    description: "Prev hunk",
-                },
-                KeyEntry {
-                    key: "]b",
-                    description: "Next bookmark",
-                },
-                KeyEntry {
-                    key: "[b",
-                    description: "Prev bookmark",
-                },
-                KeyEntry {
-                    key: "b",
-                    description: "Toggle bookmark",
-                },
-                KeyEntry {
-                    key: "B",
-                    description: "Bookmark list",
-                },
-                KeyEntry {
-                    key: "m+a-z",
-                    description: "Named bookmark",
-                },
-                KeyEntry {
-                    key: "'+a-z",
-                    description: "Jump to mark",
-                },
-                KeyEntry {
-                    key: "p",
-                    description: "Prompt preview",
-                },
-                KeyEntry {
-                    key: "y",
-                    description: "Copy prompt",
-                },
-                KeyEntry {
-                    key: "1-5",
-                    description: "Quick score",
-                },
-                KeyEntry {
-                    key: "0",
-                    description: "Remove score",
-                },
-                KeyEntry {
-                    key: "s",
-                    description: "Stage file",
-                },
-                KeyEntry {
-                    key: "u",
-                    description: "Unstage file",
-                },
-                KeyEntry {
-                    key: "w",
-                    description: "Toggle whitespace",
-                },
-                KeyEntry {
-                    key: "Tab",
-                    description: "Split/unified",
-                },
-                KeyEntry {
-                    key: ":",
-                    description: "Command bar",
-                },
-                KeyEntry {
-                    key: "Ctrl+P",
-                    description: "File picker",
-                },
-                KeyEntry {
-                    key: "Ctrl+E",
-                    description: "Export feedback",
-                },
-                KeyEntry {
-                    key: "?",
-                    description: "This help",
-                },
-                KeyEntry {
-                    key: "Ctrl+C/D",
-                    description: "Quit",
-                },
-            ],
+            FocusPanel::DiffView => {
+                let mut entries = vec![
+                    KeyEntry {
+                        key: "j/k",
+                        description: "Scroll",
+                    },
+                    KeyEntry {
+                        key: "g/G",
+                        description: "Top/bottom",
+                    },
+                    KeyEntry {
+                        key: "^W h/l",
+                        description: "Switch pane",
+                    },
+                    KeyEntry {
+                        key: "PgUp/Dn",
+                        description: "Page scroll",
+                    },
+                    KeyEntry {
+                        key: "Space",
+                        description: "Expand context",
+                    },
+                    KeyEntry {
+                        key: "e",
+                        description: "Open in $EDITOR",
+                    },
+                    KeyEntry {
+                        key: "/",
+                        description: "Search in diff",
+                    },
+                    KeyEntry {
+                        key: "n/N",
+                        description: "Next/prev match",
+                    },
+                    KeyEntry {
+                        key: "v",
+                        description: "Visual select",
+                    },
+                    KeyEntry {
+                        key: "i",
+                        description: "Add annotation",
+                    },
+                    KeyEntry {
+                        key: "a",
+                        description: "Annotation menu",
+                    },
+                    KeyEntry {
+                        key: "]",
+                        description: "Next hunk",
+                    },
+                    KeyEntry {
+                        key: "[",
+                        description: "Prev hunk",
+                    },
+                    KeyEntry {
+                        key: "]b",
+                        description: "Next bookmark",
+                    },
+                    KeyEntry {
+                        key: "[b",
+                        description: "Prev bookmark",
+                    },
+                    KeyEntry {
+                        key: "b",
+                        description: "Toggle bookmark",
+                    },
+                    KeyEntry {
+                        key: "B",
+                        description: "Bookmark list",
+                    },
+                    KeyEntry {
+                        key: "m+a-z",
+                        description: "Named bookmark",
+                    },
+                    KeyEntry {
+                        key: "'+a-z",
+                        description: "Jump to mark",
+                    },
+                    KeyEntry {
+                        key: "p",
+                        description: "Prompt preview",
+                    },
+                    KeyEntry {
+                        key: "y",
+                        description: "Copy prompt",
+                    },
+                    KeyEntry {
+                        key: "1-5",
+                        description: "Quick score",
+                    },
+                    KeyEntry {
+                        key: "0",
+                        description: "Remove score",
+                    },
+                    KeyEntry {
+                        key: "s",
+                        description: "Stage file",
+                    },
+                    KeyEntry {
+                        key: "u",
+                        description: "Unstage file",
+                    },
+                    KeyEntry {
+                        key: "w",
+                        description: "Toggle whitespace",
+                    },
+                    KeyEntry {
+                        key: "Tab",
+                        description: "Split/unified",
+                    },
+                    KeyEntry {
+                        key: ":",
+                        description: "Command bar",
+                    },
+                    KeyEntry {
+                        key: "Ctrl+P",
+                        description: "File picker",
+                    },
+                    KeyEntry {
+                        key: "Ctrl+E",
+                        description: "Export feedback",
+                    },
+                    KeyEntry {
+                        key: "?",
+                        description: "This help",
+                    },
+                    KeyEntry {
+                        key: "Ctrl+C/D",
+                        description: "Quit",
+                    },
+                ];
+                if state.timeline.active {
+                    entries.extend_from_slice(&[
+                        KeyEntry {
+                            key: "< / ,",
+                            description: "Prev commit",
+                        },
+                        KeyEntry {
+                            key: "> / .",
+                            description: "Next commit",
+                        },
+                        KeyEntry {
+                            key: "0",
+                            description: "All commits",
+                        },
+                    ]);
+                }
+                entries.push(KeyEntry {
+                    key: "Ctrl+T",
+                    description: if state.timeline.active {
+                        "Hide timeline"
+                    } else {
+                        "Timeline"
+                    },
+                });
+                entries
+            }
             FocusPanel::ReviewPanel => vec![
                 KeyEntry {
                     key: "type",

--- a/src/event.rs
+++ b/src/event.rs
@@ -120,6 +120,7 @@ pub struct KeyContext {
     pub agentic_review_panel_open: bool,
     pub agentic_review_composing: bool,
     pub window_pending: bool,
+    pub timeline_active: bool,
 }
 
 /// Context for mouse event mapping.
@@ -550,6 +551,15 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
         }
     }
 
+    // Priority 3.9: Timeline scrubber navigation (when timeline is active and in DiffExplorer)
+    if ctx.timeline_active && ctx.active_view == ActiveView::DiffExplorer && !review_composing {
+        match key.code {
+            KeyCode::Char('>') | KeyCode::Char('.') => return Some(Action::TimelineNext),
+            KeyCode::Char('<') | KeyCode::Char(',') => return Some(Action::TimelinePrev),
+            _ => {}
+        }
+    }
+
     // Priority 4: Global bindings (always active)
     match key.code {
         KeyCode::Char('w') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -569,6 +579,9 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
         }
         KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             return Some(Action::OpenAgenticReview)
+        }
+        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            return Some(Action::ToggleTimeline)
         }
         _ => {}
     }
@@ -783,6 +796,7 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
             KeyCode::Char('3') => Some(Action::SetLineScore(3)),
             KeyCode::Char('4') => Some(Action::SetLineScore(4)),
             KeyCode::Char('5') => Some(Action::SetLineScore(5)),
+            KeyCode::Char('0') if ctx.timeline_active => Some(Action::TimelineSelectAll),
             KeyCode::Char('0') => Some(Action::RemoveLineScore),
             _ => None,
         },
@@ -905,6 +919,7 @@ mod tests {
             agentic_review_panel_open: false,
             agentic_review_composing: false,
             window_pending: false,
+            timeline_active: false,
         }
     }
 
@@ -940,6 +955,7 @@ mod tests {
             agentic_review_panel_open: false,
             agentic_review_composing: false,
             window_pending: false,
+            timeline_active: false,
         }
     }
 
@@ -975,6 +991,7 @@ mod tests {
             agentic_review_panel_open: true,
             agentic_review_composing: true,
             window_pending: false,
+            timeline_active: false,
         }
     }
 

--- a/src/git/attribution.rs
+++ b/src/git/attribution.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use git2::Repository;
+
+use crate::git::types::ComparisonTarget;
+use crate::state::timeline_state::TimelineCommit;
+
+/// Collect commits in the diff range, returning them in chronological order
+/// (oldest first). For Branch/Commit targets this walks from HEAD back to the
+/// merge-base. For HeadVsWorkdir it returns the single HEAD commit (if any).
+pub fn collect_timeline_commits(
+    repo: &Repository,
+    target: &ComparisonTarget,
+) -> Result<Vec<TimelineCommit>> {
+    let head_commit = match repo.head() {
+        Ok(head) => head.peel_to_commit()?.id(),
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let base_oid = match target {
+        ComparisonTarget::HeadVsWorkdir => {
+            return Ok(vec![commit_to_timeline(repo, head_commit)?]);
+        }
+        ComparisonTarget::Branch(name) => {
+            let obj = repo.revparse_single(name)?;
+            let target_commit = obj.peel_to_commit()?;
+            match repo.merge_base(head_commit, target_commit.id()) {
+                Ok(base) => base,
+                Err(_) => target_commit.id(),
+            }
+        }
+        ComparisonTarget::Commit(oid) => match repo.merge_base(head_commit, *oid) {
+            Ok(base) => base,
+            Err(_) => *oid,
+        },
+    };
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(head_commit)?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)?;
+
+    let mut commits = Vec::new();
+    for oid_result in revwalk {
+        let oid = oid_result?;
+        if oid == base_oid {
+            continue;
+        }
+        let commit = repo.find_commit(oid)?;
+        if commit.parent_ids().any(|parent_id| parent_id == base_oid)
+            || commits
+                .iter()
+                .any(|c: &TimelineCommit| commit.parent_ids().any(|pid| pid.to_string() == c.oid))
+            || commits.is_empty()
+        {
+            commits.push(commit_to_timeline(repo, oid)?);
+        } else {
+            let is_descendant = commit.parent_ids().any(|pid| {
+                commits
+                    .iter()
+                    .any(|c: &TimelineCommit| c.oid == pid.to_string())
+            });
+            if !is_descendant {
+                // Commit is still after base but not directly chained; include it
+                // if it's reachable from base (revwalk already ensures this).
+                commits.push(commit_to_timeline(repo, oid)?);
+            }
+        }
+    }
+
+    Ok(commits)
+}
+
+fn commit_to_timeline(repo: &Repository, oid: git2::Oid) -> Result<TimelineCommit> {
+    let commit = repo.find_commit(oid)?;
+    let summary = commit.summary().unwrap_or("<no message>").to_string();
+    let author = commit.author().name().unwrap_or("unknown").to_string();
+    let time = commit.time();
+    let timestamp = format_timestamp(time.seconds());
+
+    let (files_changed, additions, deletions) = commit_stats(repo, &commit)?;
+
+    Ok(TimelineCommit {
+        oid: oid.to_string(),
+        summary,
+        author,
+        timestamp,
+        files_changed,
+        additions,
+        deletions,
+    })
+}
+
+fn commit_stats(repo: &Repository, commit: &git2::Commit<'_>) -> Result<(usize, usize, usize)> {
+    let tree = commit.tree()?;
+    let parent_tree = if commit.parent_count() > 0 {
+        Some(commit.parent(0)?.tree()?)
+    } else {
+        None
+    };
+
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)?;
+    let stats = diff.stats()?;
+
+    Ok((stats.files_changed(), stats.insertions(), stats.deletions()))
+}
+
+fn format_timestamp(seconds: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let delta = now - seconds;
+    if delta < 60 {
+        "just now".to_string()
+    } else if delta < 3600 {
+        format!("{}m ago", delta / 60)
+    } else if delta < 86400 {
+        format!("{}h ago", delta / 3600)
+    } else {
+        format!("{}d ago", delta / 86400)
+    }
+}

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -7,6 +7,39 @@ use crate::state::diff_state::DiffOptions as AppDiffOptions;
 pub struct DiffEngine;
 
 impl DiffEngine {
+    /// Compute the diff for a single commit (parent..commit).
+    pub fn compute_commit_diff(
+        repo: &Repository,
+        commit_oid: &str,
+        options: &AppDiffOptions,
+    ) -> Result<Vec<FileDelta>> {
+        let obj = repo
+            .revparse_single(commit_oid)
+            .with_context(|| format!("Could not resolve: {commit_oid}"))?;
+        let commit = obj
+            .peel_to_commit()
+            .with_context(|| format!("{commit_oid} does not point to a commit"))?;
+
+        let commit_tree = commit.tree()?;
+        let parent_tree = if commit.parent_count() > 0 {
+            Some(commit.parent(0)?.tree()?)
+        } else {
+            None
+        };
+
+        let mut diff_opts = DiffOptions::new();
+        diff_opts.ignore_whitespace(options.ignore_whitespace);
+        diff_opts.context_lines(999_999);
+
+        let diff = repo.diff_tree_to_tree(
+            parent_tree.as_ref(),
+            Some(&commit_tree),
+            Some(&mut diff_opts),
+        )?;
+
+        Self::parse_diff(&diff)
+    }
+
     pub fn compute_diff(
         repo: &Repository,
         target: &ComparisonTarget,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,3 +1,4 @@
+pub mod attribution;
 pub mod commands;
 pub mod diff;
 pub mod repository;

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -3,7 +3,7 @@ use crate::theme::Theme;
 use super::{
     AgentOutputsState, AgentSelectorState, AnnotationState, BookmarkState, ChecklistState,
     CommandBarState, DiffOptions, DiffState, FilePickerState, GlobalSearchState, NavigatorState,
-    ReviewState, SelectionState, TextBuffer, WorktreeState,
+    ReviewState, SelectionState, TextBuffer, TimelineState, WorktreeState,
 };
 
 use super::annotation_state::{AnnotationCategory, AnnotationSeverity};
@@ -157,6 +157,9 @@ pub struct AppState {
     // File picker (Ctrl+P)
     pub file_picker: FilePickerState,
 
+    // Timeline scrubber
+    pub timeline: TimelineState,
+
     // Agentic review
     pub agentic_review_modal_open: bool, // kept for KeyContext compat, always false now
     pub agentic_review_composing: bool,
@@ -214,6 +217,7 @@ impl AppState {
             bookmarks: BookmarkState::new(),
             command_bar: CommandBarState::new(),
             file_picker: FilePickerState::new(),
+            timeline: TimelineState::default(),
             agentic_review_modal_open: false,
             agentic_review_composing: false,
             agentic_review_text: TextBuffer::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,6 +12,7 @@ pub mod search_state;
 pub mod selection_state;
 pub mod settings_state;
 pub mod text_buffer;
+pub mod timeline_state;
 pub mod worktree_state;
 
 pub use agent_state::{AgentOutputsState, AgentSelectorState};
@@ -27,4 +28,5 @@ pub use review_state::ReviewState;
 pub use search_state::GlobalSearchState;
 pub use selection_state::SelectionState;
 pub use text_buffer::TextBuffer;
+pub use timeline_state::TimelineState;
 pub use worktree_state::WorktreeState;

--- a/src/state/timeline_state.rs
+++ b/src/state/timeline_state.rs
@@ -1,0 +1,66 @@
+use crate::git::types::FileDelta;
+
+#[derive(Debug, Clone)]
+pub struct TimelineCommit {
+    pub oid: String,
+    pub summary: String,
+    pub author: String,
+    pub timestamp: String,
+    pub files_changed: usize,
+    pub additions: usize,
+    pub deletions: usize,
+}
+
+#[derive(Default)]
+pub struct TimelineState {
+    pub active: bool,
+    pub commits: Vec<TimelineCommit>,
+    /// None = show all (combined diff), Some(i) = show only commit i's diff.
+    pub selected_index: Option<usize>,
+    /// Cached combined diff (the original full-range diff).
+    pub cached_combined_deltas: Vec<FileDelta>,
+}
+
+impl TimelineState {
+    pub fn select_next(&mut self) {
+        if self.commits.is_empty() {
+            return;
+        }
+        match self.selected_index {
+            None => {
+                self.selected_index = Some(0);
+            }
+            Some(i) => {
+                if i + 1 < self.commits.len() {
+                    self.selected_index = Some(i + 1);
+                }
+            }
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        match self.selected_index {
+            None => {}
+            Some(0) => {
+                self.selected_index = None;
+            }
+            Some(i) => {
+                self.selected_index = Some(i - 1);
+            }
+        }
+    }
+
+    pub fn select_all(&mut self) {
+        self.selected_index = None;
+    }
+
+    pub fn status_text(&self) -> String {
+        if self.commits.is_empty() {
+            return String::new();
+        }
+        match self.selected_index {
+            None => format!("ALL ({} commits)", self.commits.len()),
+            Some(i) => format!("[{}/{}]", i + 1, self.commits.len()),
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User Problem
When reviewing multi-commit agent output, all changes are flattened into a single diff view. Reviewers cannot see how the agent iterated — which commit added a feature, which fixed a bug, which added tests. This makes it impossible to understand the agent's reasoning process or isolate the commit that introduced a specific change. Users currently have to exit mdiff and use git log to inspect individual commits.

## Planned Approach
Add a TimelineState that collects commits in the diff range, a horizontal timeline bar component at the bottom of the diff view, and keyboard navigation (< and >) to scrub between commits. When a commit is selected, the diff engine computes a parent..commit diff and replaces the displayed deltas. The combined diff is cached for instant restoration when the user returns to "all" mode. Integrates with existing attribution infrastructure.

## User Benefit
Provides commit-by-commit time travel through agent iterations without leaving the TUI. Reviewers can understand the agent's step-by-step reasoning, isolate specific commits for focused review, and quickly identify which iteration introduced a concern. Reduces the need to context-switch to git log or external tools.

## Visual Preview
[Visual mockup will be added by the ideation agent]

## Spec Reference
See `.github/specs/033-diff-timeline-scrubber.md`

## Implementation Details

### New files
- `src/state/timeline_state.rs` — `TimelineState` and `TimelineCommit` structs with navigation methods
- `src/git/attribution.rs` — `collect_timeline_commits()` walks the commit graph from merge-base to HEAD, enriching each commit with file stats
- `src/components/timeline_bar.rs` — horizontal bar at bottom of diff view showing numbered commit markers with selection highlighting

### Modified files
- `src/action.rs` — added `ToggleTimeline`, `TimelineNext`, `TimelinePrev`, `TimelineSelectAll` action variants
- `src/event.rs` — `Ctrl+T` toggles timeline; `<`/`,` and `>`/`.` navigate; `0` returns to combined view (when timeline active)
- `src/git/diff.rs` — added `DiffEngine::compute_commit_diff()` for single-commit (parent..commit) diffs
- `src/app.rs` — timeline action handling, timeline bar rendering integration, helper methods for activation/selection/restoration
- `src/state/app_state.rs` — added `timeline: TimelineState` field
- `src/state/mod.rs` — re-exports `TimelineState`
- `src/git/mod.rs` — added `attribution` module
- `src/components/mod.rs` — added `timeline_bar` module
- `src/components/diff_view.rs` — title shows `[N/M] summary` when timeline commit is selected
- `src/components/which_key.rs` — timeline controls shown when active (`Ctrl+T`, `</>`, `0`)
- `src/components/action_hud.rs` — `timeline_active` field added to test KeyContext

### Key design decisions
- Combined diff is cached in `TimelineState.cached_combined_deltas` so switching back to "all" is instant (no recomputation)
- Single-commit diffs are computed synchronously on selection change using `git2`'s tree-to-tree diff
- Navigator file list updates automatically when a commit is selected (showing only that commit's files)
- Timeline bar uses 1 row at the bottom of the diff area, only visible when active

### Verification
- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` — all 66 tests pass ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b42db32f-1c5d-4747-bddb-714c0408cbba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b42db32f-1c5d-4747-bddb-714c0408cbba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

