### PR TITLE
feat: implement automated review surface for AI-generated findings

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -277,4 +277,14 @@ pub enum Action {
     AgenticReviewError(String),
     AgenticReviewPanelUp,
     AgenticReviewPanelDown,
+
+    // Auto-review findings panel
+    AutoReviewNext,
+    AutoReviewPrev,
+    AutoReviewAccept,
+    AutoReviewDismiss,
+    AutoReviewEdit,
+    AutoReviewJumpToCode,
+    AutoReviewFilterCycle,
+    AutoReviewClose,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use crate::components::agent_outputs::AgentOutputs;
 use crate::components::agent_selector::render_agent_selector;
 use crate::components::agentic_review_panel::AgenticReviewPanel;
 use crate::components::annotation_menu::render_annotation_menu;
+use crate::components::auto_review_panel::AutoReviewPanel;
 use crate::components::bookmark_list::render_bookmark_list;
 use crate::components::checklist_panel::ChecklistPanel;
 use crate::components::command_bar::render_command_bar;
@@ -48,6 +49,7 @@ use crate::session;
 use crate::state::agent_state::{AgentRun, AgentRunStatus};
 use crate::state::annotation_state::{Annotation, LineAnchor};
 use crate::state::app_state::{ActiveView, FocusPanel};
+use crate::state::auto_review_state::FindingStatus;
 use crate::state::file_picker_state::FilePickerEntry;
 use crate::state::review_state::{compute_diff_hashes, FileReviewStatus};
 use crate::state::settings_state::SETTINGS_ROW_COUNT;
@@ -89,6 +91,7 @@ pub struct App {
     jump_mark_pending: bool,
     window_pending: bool,
     agentic_review_runner: Option<crate::agentic_review::AgenticReviewRunner>,
+    auto_review_editing_index: Option<usize>,
 }
 
 impl App {
@@ -161,6 +164,7 @@ impl App {
             jump_mark_pending: false,
             window_pending: false,
             agentic_review_runner: None,
+            auto_review_editing_index: None,
         }
     }
 
@@ -180,6 +184,7 @@ impl App {
         let agent_outputs = AgentOutputs;
         let checklist_panel = ChecklistPanel;
         let agentic_review_panel = AgenticReviewPanel;
+        let auto_review_panel = AutoReviewPanel;
 
         loop {
             self.poll_diff_results();
@@ -209,37 +214,52 @@ impl App {
                                 || self.state.agentic_review_running
                                 || self.state.agentic_review_composing
                                 || !self.state.agentic_review_text.text().is_empty());
+                        let show_auto_review = self.state.auto_review.panel_open
+                            && self.state.auto_review.has_findings();
 
-                        let main = if show_checklist && show_ai_review {
-                            // Four-column: navigator | diff | checklist | ai review
-                            Layout::default()
-                                .direction(Direction::Horizontal)
-                                .constraints([
+                        let right_panel_count = [show_checklist, show_ai_review, show_auto_review]
+                            .iter()
+                            .filter(|&&b| b)
+                            .count();
+
+                        let main = match right_panel_count {
+                            0 => {
+                                // Two-column layout: navigator | diff
+                                Layout::default()
+                                    .direction(Direction::Horizontal)
+                                    .constraints([
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(80),
+                                    ])
+                                    .split(outer[1])
+                            }
+                            1 => {
+                                // Three-column: navigator | diff | panel
+                                Layout::default()
+                                    .direction(Direction::Horizontal)
+                                    .constraints([
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(55),
+                                        Constraint::Percentage(25),
+                                    ])
+                                    .split(outer[1])
+                            }
+                            _ => {
+                                // N-column layout for multiple panels
+                                let pct = 20u16 / right_panel_count as u16;
+                                let diff_pct = 100u16 - 15 - (pct * right_panel_count as u16);
+                                let mut c = vec![
                                     Constraint::Percentage(15),
-                                    Constraint::Percentage(45),
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(20),
-                                ])
-                                .split(outer[1])
-                        } else if show_checklist || show_ai_review {
-                            // Three-column: navigator | diff | panel
-                            Layout::default()
-                                .direction(Direction::Horizontal)
-                                .constraints([
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(60),
-                                    Constraint::Percentage(20),
-                                ])
-                                .split(outer[1])
-                        } else {
-                            // Two-column layout: navigator | diff
-                            Layout::default()
-                                .direction(Direction::Horizontal)
-                                .constraints([
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(80),
-                                ])
-                                .split(outer[1])
+                                    Constraint::Percentage(diff_pct),
+                                ];
+                                for _ in 0..right_panel_count {
+                                    c.push(Constraint::Percentage(pct));
+                                }
+                                Layout::default()
+                                    .direction(Direction::Horizontal)
+                                    .constraints(c)
+                                    .split(outer[1])
+                            }
                         };
 
                         self.nav_area.set(main[0]);
@@ -274,13 +294,17 @@ impl App {
                         }
 
                         // Render right-side panels
-                        if show_checklist && show_ai_review {
-                            checklist_panel.render(frame, main[2], &self.state);
-                            agentic_review_panel.render(frame, main[3], &self.state);
-                        } else if show_checklist {
-                            checklist_panel.render(frame, main[2], &self.state);
-                        } else if show_ai_review {
-                            agentic_review_panel.render(frame, main[2], &self.state);
+                        let mut panel_idx = 2;
+                        if show_checklist && panel_idx < main.len() {
+                            checklist_panel.render(frame, main[panel_idx], &self.state);
+                            panel_idx += 1;
+                        }
+                        if show_ai_review && panel_idx < main.len() {
+                            agentic_review_panel.render(frame, main[panel_idx], &self.state);
+                            panel_idx += 1;
+                        }
+                        if show_auto_review && panel_idx < main.len() {
+                            auto_review_panel.render(frame, main[panel_idx], &self.state);
                         }
                     }
                     ActiveView::WorktreeBrowser => {
@@ -389,6 +413,8 @@ impl App {
                     agentic_review_modal_open: self.state.agentic_review_modal_open,
                     agentic_review_panel_open: self.state.agentic_review_panel_open,
                     agentic_review_composing: self.state.agentic_review_composing,
+                    auto_review_panel_open: self.state.auto_review.panel_open
+                        && self.state.auto_review.has_findings(),
                     window_pending: self.window_pending,
                 };
                 let action = match event {
@@ -940,6 +966,14 @@ impl App {
                 | Action::AgenticReviewError(_)
                 | Action::AgenticReviewPanelUp
                 | Action::AgenticReviewPanelDown
+                | Action::AutoReviewNext
+                | Action::AutoReviewPrev
+                | Action::AutoReviewAccept
+                | Action::AutoReviewDismiss
+                | Action::AutoReviewEdit
+                | Action::AutoReviewJumpToCode
+                | Action::AutoReviewFilterCycle
+                | Action::AutoReviewClose
                 | Action::WindowPrefix
                 | Action::CycleFocus => {}
                 _ => {
@@ -1609,11 +1643,37 @@ impl App {
                 self.state.comment_editor_open = false;
                 self.state.comment_editor_text.clear();
                 self.state.editing_annotation = None;
+                self.auto_review_editing_index = None;
             }
             Action::ConfirmComment => {
                 use crate::state::annotation_state::{AnnotationCategory, AnnotationSeverity};
                 if !self.state.comment_editor_text.text().trim().is_empty() {
-                    if let Some(editing) = self.state.editing_annotation.take() {
+                    if let Some(ar_idx) = self.auto_review_editing_index.take() {
+                        // Editing an auto-review finding before accepting
+                        let comment_text = self.state.comment_editor_text.text().to_string();
+                        if let Some(finding) = self.state.auto_review.findings.get_mut(ar_idx) {
+                            finding.comment = comment_text;
+                            finding.status = FindingStatus::Accepted;
+                            let annotation = finding.to_annotation();
+                            self.state.annotations.add(annotation);
+                            self.set_status(
+                                "Finding edited and accepted as annotation".to_string(),
+                                false,
+                            );
+                            session::save_session_data(
+                                &self.repo_path,
+                                &self.state.target_label,
+                                &self.state.annotations,
+                                if self.state.checklist.is_empty() {
+                                    None
+                                } else {
+                                    Some(&self.state.checklist)
+                                },
+                                &self.state.bookmarks,
+                            );
+                        }
+                        self.state.editing_annotation = None;
+                    } else if let Some(editing) = self.state.editing_annotation.take() {
                         // Editing an existing annotation from the annotation menu
                         let comment_text = self.state.comment_editor_text.text().to_string();
                         self.state.annotations.update_comment(
@@ -3036,9 +3096,15 @@ impl App {
                 self.agentic_review_runner = None;
                 let count = annotations.len();
                 let summary = self.build_agentic_review_summary(&annotations);
-                for ann in annotations {
-                    self.state.annotations.add(ann);
+
+                // Populate auto-review findings for interactive triage
+                // (do NOT add to AnnotationState yet — user triages first)
+                if !annotations.is_empty() {
+                    self.state.auto_review.populate(&annotations);
+                    self.state.focus = FocusPanel::ReviewPanel;
+                    self.state.agentic_review_composing = false;
                 }
+
                 self.state.agentic_review_stream_output.push_str(&summary);
                 if self.state.prompt_preview_visible {
                     self.update_prompt_preview();
@@ -3055,7 +3121,7 @@ impl App {
                     &self.state.bookmarks,
                 );
                 self.state.status_message = Some((
-                    format!("Agentic review: {count} annotation(s) created."),
+                    format!("Agentic review: {count} finding(s) ready for triage."),
                     false,
                 ));
                 self.status_clear_countdown = 120;
@@ -3077,6 +3143,93 @@ impl App {
             Action::AgenticReviewPanelDown => {
                 self.state.agentic_review_scroll += 1;
                 // Don't re-enable auto_scroll — user is manually scrolling
+            }
+
+            // Auto-review findings panel
+            Action::AutoReviewNext => {
+                self.state.auto_review.select_next();
+            }
+            Action::AutoReviewPrev => {
+                self.state.auto_review.select_prev();
+            }
+            Action::AutoReviewAccept => {
+                let ar = &mut self.state.auto_review;
+                if let Some(finding) = ar.findings.get_mut(ar.selected) {
+                    if finding.status != FindingStatus::Accepted {
+                        finding.status = FindingStatus::Accepted;
+                        let annotation = finding.to_annotation();
+                        self.state.annotations.add(annotation);
+                        self.set_status("Finding accepted as annotation".to_string(), false);
+                        session::save_session_data(
+                            &self.repo_path,
+                            &self.state.target_label,
+                            &self.state.annotations,
+                            if self.state.checklist.is_empty() {
+                                None
+                            } else {
+                                Some(&self.state.checklist)
+                            },
+                            &self.state.bookmarks,
+                        );
+                    }
+                }
+            }
+            Action::AutoReviewDismiss => {
+                let ar = &mut self.state.auto_review;
+                if let Some(finding) = ar.findings.get_mut(ar.selected) {
+                    finding.status = FindingStatus::Dismissed;
+                    self.set_status("Finding dismissed".to_string(), false);
+                }
+            }
+            Action::AutoReviewEdit => {
+                let ar = &self.state.auto_review;
+                if let Some(finding) = ar.findings.get(ar.selected) {
+                    self.state.editing_annotation =
+                        Some(crate::state::app_state::EditingAnnotation {
+                            file_path: finding.file_path.clone(),
+                            old_range: finding.old_range,
+                            new_range: finding.new_range,
+                            old_comment: String::new(),
+                        });
+                    self.state.comment_editor_open = true;
+                    self.state.comment_editor_text.set(&finding.comment);
+                    self.auto_review_editing_index = Some(ar.selected);
+                }
+            }
+            Action::AutoReviewJumpToCode => {
+                let ar = &self.state.auto_review;
+                if let Some(finding) = ar.findings.get(ar.selected) {
+                    let file_path = finding.file_path.clone();
+                    let target_line = finding.sort_line();
+
+                    if let Some(idx) = self
+                        .state
+                        .diff
+                        .deltas
+                        .iter()
+                        .position(|d| d.path.to_string_lossy() == file_path)
+                    {
+                        self.state.navigator.selected = idx;
+                        self.state.diff.selected_file = Some(idx);
+                        self.request_diff();
+                        self.state.agentic_review_composing = false;
+                        if target_line > 0 {
+                            self.goto_line(target_line);
+                        } else {
+                            self.state.focus = FocusPanel::DiffView;
+                        }
+                    }
+                }
+            }
+            Action::AutoReviewFilterCycle => {
+                self.state.auto_review.filter = self.state.auto_review.filter.cycle();
+                let label = self.state.auto_review.filter.label();
+                self.set_status(format!("Filter: {label}"), false);
+            }
+            Action::AutoReviewClose => {
+                self.state.auto_review.panel_open = false;
+                self.state.focus = FocusPanel::DiffView;
+                self.state.agentic_review_composing = false;
             }
         }
     }

--- a/src/components/action_hud.rs
+++ b/src/components/action_hud.rs
@@ -348,6 +348,8 @@ mod tests {
             agentic_review_modal_open: state.agentic_review_modal_open,
             agentic_review_panel_open: state.agentic_review_panel_open,
             agentic_review_composing: state.agentic_review_composing,
+            auto_review_panel_open: state.auto_review.panel_open
+                && state.auto_review.has_findings(),
             window_pending: false,
         }
     }

--- a/src/components/auto_review_panel.rs
+++ b/src/components/auto_review_panel.rs
@@ -1,0 +1,268 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::state::app_state::FocusPanel;
+use crate::state::auto_review_state::FindingStatus;
+use crate::state::AppState;
+
+use super::Component;
+
+pub struct AutoReviewPanel;
+
+impl Component for AutoReviewPanel {
+    fn render(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        let theme = &state.theme;
+        let ar = &state.auto_review;
+        let focused = state.focus == FocusPanel::ReviewPanel;
+
+        let (reviewed, total) = ar.reviewed_count();
+        let filter_label = ar.filter.label();
+        let title = format!(" Findings {reviewed}/{total} [{filter_label}] ");
+
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(if focused {
+                theme.accent
+            } else {
+                theme.text_muted
+            }));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if inner.height < 3 || ar.findings.is_empty() {
+            if ar.findings.is_empty() {
+                let msg =
+                    Paragraph::new(" No findings").style(Style::default().fg(theme.text_muted));
+                frame.render_widget(msg, inner);
+            }
+            return;
+        }
+
+        let detail_height = 6u16;
+        let hints_height = 1u16;
+        let list_height = inner
+            .height
+            .saturating_sub(detail_height + hints_height + 1);
+
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(list_height.max(3)),
+                Constraint::Length(1), // separator
+                Constraint::Length(detail_height),
+                Constraint::Length(hints_height),
+            ])
+            .split(inner);
+
+        let filtered = ar.filtered_indices();
+
+        // Determine scroll for the list
+        let selected_pos = filtered.iter().position(|&i| i == ar.selected).unwrap_or(0);
+        let visible_rows = list_height as usize;
+        let scroll = if selected_pos >= ar.scroll_offset + visible_rows {
+            selected_pos.saturating_sub(visible_rows - 1)
+        } else if selected_pos < ar.scroll_offset {
+            selected_pos
+        } else {
+            ar.scroll_offset
+        };
+
+        // Render findings list
+        let mut lines: Vec<Line> = Vec::new();
+        let mut current_file: Option<&str> = None;
+
+        for &idx in filtered.iter().skip(scroll).take(visible_rows) {
+            let finding = &ar.findings[idx];
+            let is_selected = idx == ar.selected;
+
+            // File header when file changes
+            if current_file != Some(&finding.file_path) {
+                current_file = Some(&finding.file_path);
+                if !lines.is_empty() && lines.len() < visible_rows {
+                    lines.push(Line::from(""));
+                }
+                if lines.len() < visible_rows {
+                    lines.push(Line::from(Span::styled(
+                        format!(" {}", finding.file_path),
+                        Style::default()
+                            .fg(theme.accent)
+                            .add_modifier(Modifier::BOLD),
+                    )));
+                }
+            }
+
+            if lines.len() >= visible_rows {
+                break;
+            }
+
+            let status_icon = finding.status.icon();
+            let severity_color = severity_color(finding.severity, theme);
+            let severity_label = finding.severity.label();
+            let category_label = finding.category.label();
+            let range = finding.range_text();
+
+            let dimmed = finding.status == FindingStatus::Dismissed;
+            let text_style = if dimmed {
+                Style::default().fg(theme.text_muted)
+            } else if is_selected {
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text)
+            };
+
+            let prefix = if is_selected && focused { "▸" } else { " " };
+
+            let truncated_comment: String = {
+                let max_len = (inner.width as usize).saturating_sub(30);
+                let first_line = finding.comment.lines().next().unwrap_or("");
+                if first_line.len() > max_len {
+                    format!("{}…", &first_line[..max_len.saturating_sub(1)])
+                } else {
+                    first_line.to_string()
+                }
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{prefix}{status_icon} "),
+                    Style::default().fg(if dimmed {
+                        theme.text_muted
+                    } else {
+                        match finding.status {
+                            FindingStatus::Pending => theme.warning,
+                            FindingStatus::Accepted => Color::Green,
+                            FindingStatus::Dismissed => theme.text_muted,
+                        }
+                    }),
+                ),
+                Span::styled(
+                    severity_label.to_string(),
+                    Style::default().fg(severity_color),
+                ),
+                Span::styled(
+                    format!(" {category_label}"),
+                    Style::default().fg(theme.text_muted),
+                ),
+                Span::styled(format!(" {range} "), Style::default().fg(theme.text_muted)),
+                Span::styled(truncated_comment, text_style),
+            ]));
+        }
+
+        let list_widget = Paragraph::new(lines);
+        frame.render_widget(list_widget, layout[0]);
+
+        // Separator
+        let sep = Paragraph::new(Line::from("─".repeat(inner.width as usize)))
+            .style(Style::default().fg(theme.text_muted));
+        frame.render_widget(sep, layout[1]);
+
+        // Detail area for selected finding
+        if let Some(finding) = ar.findings.get(ar.selected) {
+            let detail_lines: Vec<Line> = vec![
+                Line::from(vec![
+                    Span::styled(
+                        format!("{} ", finding.severity.label()),
+                        Style::default().fg(severity_color(finding.severity, theme)),
+                    ),
+                    Span::styled(
+                        format!("[{}] ", finding.category.label()),
+                        Style::default()
+                            .fg(theme.accent)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        finding.status.label(),
+                        Style::default().fg(match finding.status {
+                            FindingStatus::Pending => theme.warning,
+                            FindingStatus::Accepted => Color::Green,
+                            FindingStatus::Dismissed => theme.text_muted,
+                        }),
+                    ),
+                ]),
+                Line::from(Span::styled(
+                    format!("{} {}", finding.file_path, finding.range_text()),
+                    Style::default().fg(theme.text_muted),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    &finding.comment,
+                    Style::default().fg(if finding.status == FindingStatus::Dismissed {
+                        theme.text_muted
+                    } else {
+                        theme.text
+                    }),
+                )),
+            ];
+
+            let detail = Paragraph::new(detail_lines).wrap(Wrap { trim: false });
+            frame.render_widget(detail, layout[2]);
+        }
+
+        // Hints
+        let hints = Line::from(vec![
+            Span::styled(
+                " [j/k]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" nav ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "[Enter]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" jump ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "[a]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" accept ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "[x]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" dismiss ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "[e]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" edit ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "[f]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" filter", Style::default().fg(theme.text_muted)),
+        ]);
+        frame.render_widget(Paragraph::new(hints), layout[3]);
+    }
+}
+
+fn severity_color(
+    severity: crate::state::annotation_state::AnnotationSeverity,
+    theme: &crate::theme::Theme,
+) -> Color {
+    use crate::state::annotation_state::AnnotationSeverity;
+    match severity {
+        AnnotationSeverity::Critical => Color::Red,
+        AnnotationSeverity::Major => theme.warning,
+        AnnotationSeverity::Minor => Color::Yellow,
+        AnnotationSeverity::Info => Color::Cyan,
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_outputs;
 pub mod agent_selector;
 pub mod agentic_review_panel;
 pub mod annotation_menu;
+pub mod auto_review_panel;
 pub mod bookmark_list;
 pub mod category_picker;
 pub mod checklist_panel;

--- a/src/components/which_key.rs
+++ b/src/components/which_key.rs
@@ -138,7 +138,13 @@ fn get_context_title(state: &AppState) -> &'static str {
                 }
             }
             FocusPanel::DiffView => "Diff View",
-            FocusPanel::ReviewPanel => "Review Panel",
+            FocusPanel::ReviewPanel => {
+                if state.auto_review.panel_open && state.auto_review.has_findings() {
+                    "Auto Review"
+                } else {
+                    "Review Panel"
+                }
+            }
             FocusPanel::ChecklistPanel => "Checklist",
             _ => "Diff Explorer",
         },
@@ -502,24 +508,63 @@ fn get_context_entries(state: &AppState) -> Vec<KeyEntry> {
                     description: "Quit",
                 },
             ],
-            FocusPanel::ReviewPanel => vec![
-                KeyEntry {
-                    key: "type",
-                    description: "Compose review",
-                },
-                KeyEntry {
-                    key: "Enter",
-                    description: "Submit review",
-                },
-                KeyEntry {
-                    key: "S-Enter",
-                    description: "Newline",
-                },
-                KeyEntry {
-                    key: "^W w",
-                    description: "Switch pane",
-                },
-            ],
+            FocusPanel::ReviewPanel => {
+                if state.auto_review.panel_open && state.auto_review.has_findings() {
+                    vec![
+                        KeyEntry {
+                            key: "j/k",
+                            description: "Navigate findings",
+                        },
+                        KeyEntry {
+                            key: "Enter",
+                            description: "Jump to code",
+                        },
+                        KeyEntry {
+                            key: "a",
+                            description: "Accept finding",
+                        },
+                        KeyEntry {
+                            key: "x",
+                            description: "Dismiss finding",
+                        },
+                        KeyEntry {
+                            key: "e",
+                            description: "Edit & accept",
+                        },
+                        KeyEntry {
+                            key: "f",
+                            description: "Cycle filter",
+                        },
+                        KeyEntry {
+                            key: "Esc",
+                            description: "Close panel",
+                        },
+                        KeyEntry {
+                            key: "^W w",
+                            description: "Switch pane",
+                        },
+                    ]
+                } else {
+                    vec![
+                        KeyEntry {
+                            key: "type",
+                            description: "Compose review",
+                        },
+                        KeyEntry {
+                            key: "Enter",
+                            description: "Submit review",
+                        },
+                        KeyEntry {
+                            key: "S-Enter",
+                            description: "Newline",
+                        },
+                        KeyEntry {
+                            key: "^W w",
+                            description: "Switch pane",
+                        },
+                    ]
+                }
+            }
             FocusPanel::ChecklistPanel => vec![
                 KeyEntry {
                     key: "j/k",

--- a/src/event.rs
+++ b/src/event.rs
@@ -119,6 +119,7 @@ pub struct KeyContext {
     pub agentic_review_modal_open: bool,
     pub agentic_review_panel_open: bool,
     pub agentic_review_composing: bool,
+    pub auto_review_panel_open: bool,
     pub window_pending: bool,
 }
 
@@ -541,7 +542,25 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
         return Some(Action::ToggleWhichKey);
     }
 
-    // Priority 3.8: Agentic review panel scroll (when panel is visible)
+    // Priority 3.8: Auto-review findings panel (when panel is visible and focused)
+    if ctx.auto_review_panel_open
+        && ctx.focus == FocusPanel::ReviewPanel
+        && !ctx.agentic_review_composing
+    {
+        return match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Some(Action::AutoReviewNext),
+            KeyCode::Char('k') | KeyCode::Up => Some(Action::AutoReviewPrev),
+            KeyCode::Enter => Some(Action::AutoReviewJumpToCode),
+            KeyCode::Char('a') => Some(Action::AutoReviewAccept),
+            KeyCode::Char('x') => Some(Action::AutoReviewDismiss),
+            KeyCode::Char('e') => Some(Action::AutoReviewEdit),
+            KeyCode::Char('f') => Some(Action::AutoReviewFilterCycle),
+            KeyCode::Esc => Some(Action::AutoReviewClose),
+            _ => None,
+        };
+    }
+
+    // Priority 3.85: Agentic review panel scroll (when panel is visible)
     if ctx.agentic_review_panel_open && !ctx.agentic_review_modal_open {
         match key.code {
             KeyCode::Char('{') => return Some(Action::AgenticReviewPanelUp),
@@ -904,6 +923,7 @@ mod tests {
             agentic_review_modal_open: false,
             agentic_review_panel_open: false,
             agentic_review_composing: false,
+            auto_review_panel_open: false,
             window_pending: false,
         }
     }
@@ -939,6 +959,7 @@ mod tests {
             agentic_review_modal_open: false,
             agentic_review_panel_open: false,
             agentic_review_composing: false,
+            auto_review_panel_open: false,
             window_pending: false,
         }
     }
@@ -974,6 +995,7 @@ mod tests {
             agentic_review_modal_open: false,
             agentic_review_panel_open: true,
             agentic_review_composing: true,
+            auto_review_panel_open: false,
             window_pending: false,
         }
     }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -1,9 +1,9 @@
 use crate::theme::Theme;
 
 use super::{
-    AgentOutputsState, AgentSelectorState, AnnotationState, BookmarkState, ChecklistState,
-    CommandBarState, DiffOptions, DiffState, FilePickerState, GlobalSearchState, NavigatorState,
-    ReviewState, SelectionState, TextBuffer, WorktreeState,
+    AgentOutputsState, AgentSelectorState, AnnotationState, AutoReviewState, BookmarkState,
+    ChecklistState, CommandBarState, DiffOptions, DiffState, FilePickerState, GlobalSearchState,
+    NavigatorState, ReviewState, SelectionState, TextBuffer, WorktreeState,
 };
 
 use super::annotation_state::{AnnotationCategory, AnnotationSeverity};
@@ -168,6 +168,9 @@ pub struct AppState {
     pub agentic_review_child_total: usize,
     pub agentic_review_scroll: usize,
     pub agentic_review_auto_scroll: bool,
+
+    // Auto-review findings
+    pub auto_review: AutoReviewState,
 }
 
 impl AppState {
@@ -224,6 +227,7 @@ impl AppState {
             agentic_review_child_total: 0,
             agentic_review_scroll: 0,
             agentic_review_auto_scroll: true,
+            auto_review: AutoReviewState::default(),
         }
     }
 }

--- a/src/state/auto_review_state.rs
+++ b/src/state/auto_review_state.rs
@@ -1,0 +1,303 @@
+use crate::state::annotation_state::{Annotation, AnnotationCategory, AnnotationSeverity};
+
+/// Status of an individual review finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingStatus {
+    Pending,
+    Accepted,
+    Dismissed,
+}
+
+impl FindingStatus {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Accepted => "Accepted",
+            Self::Dismissed => "Dismissed",
+        }
+    }
+
+    pub fn icon(&self) -> &'static str {
+        match self {
+            Self::Pending => "●",
+            Self::Accepted => "✓",
+            Self::Dismissed => "✗",
+        }
+    }
+}
+
+/// Filter mode for the findings list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingFilter {
+    All,
+    Pending,
+    Accepted,
+    Dismissed,
+}
+
+impl FindingFilter {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Pending => "Pending",
+            Self::Accepted => "Accepted",
+            Self::Dismissed => "Dismissed",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::All => Self::Pending,
+            Self::Pending => Self::Accepted,
+            Self::Accepted => Self::Dismissed,
+            Self::Dismissed => Self::All,
+        }
+    }
+}
+
+/// A single AI-generated review finding.
+#[derive(Debug, Clone)]
+pub struct ReviewFinding {
+    pub file_path: String,
+    pub old_range: Option<(u32, u32)>,
+    pub new_range: Option<(u32, u32)>,
+    pub comment: String,
+    pub category: AnnotationCategory,
+    pub severity: AnnotationSeverity,
+    pub status: FindingStatus,
+}
+
+impl ReviewFinding {
+    /// Representative line for display/sorting, preferring new-file.
+    pub fn sort_line(&self) -> u32 {
+        self.new_range
+            .map(|(s, _)| s)
+            .or(self.old_range.map(|(s, _)| s))
+            .unwrap_or(0)
+    }
+
+    /// Format a human-readable range string.
+    pub fn range_text(&self) -> String {
+        match (self.old_range, self.new_range) {
+            (_, Some((s, e))) if s == e => format!("L{s}"),
+            (_, Some((s, e))) => format!("L{s}-{e}"),
+            (Some((s, e)), None) if s == e => format!("old L{s}"),
+            (Some((s, e)), None) => format!("old L{s}-{e}"),
+            (None, None) => "file".to_string(),
+        }
+    }
+
+    /// Convert this finding into an Annotation for the persistent annotation system.
+    pub fn to_annotation(&self) -> Annotation {
+        Annotation {
+            anchor: crate::state::annotation_state::LineAnchor {
+                file_path: self.file_path.clone(),
+                old_range: self.old_range,
+                new_range: self.new_range,
+            },
+            comment: self.comment.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            category: self.category,
+            severity: self.severity,
+        }
+    }
+}
+
+/// State for the auto-review findings panel.
+#[derive(Debug)]
+pub struct AutoReviewState {
+    pub findings: Vec<ReviewFinding>,
+    pub selected: usize,
+    pub filter: FindingFilter,
+    pub panel_open: bool,
+    pub scroll_offset: usize,
+}
+
+impl Default for AutoReviewState {
+    fn default() -> Self {
+        Self {
+            findings: Vec::new(),
+            selected: 0,
+            filter: FindingFilter::All,
+            panel_open: false,
+            scroll_offset: 0,
+        }
+    }
+}
+
+impl AutoReviewState {
+    /// Populate findings from completed annotations (does not add them to AnnotationState).
+    pub fn populate(&mut self, annotations: &[Annotation]) {
+        self.findings = annotations
+            .iter()
+            .map(|ann| ReviewFinding {
+                file_path: ann.anchor.file_path.clone(),
+                old_range: ann.anchor.old_range,
+                new_range: ann.anchor.new_range,
+                comment: ann.comment.clone(),
+                category: ann.category,
+                severity: ann.severity,
+                status: FindingStatus::Pending,
+            })
+            .collect();
+        self.findings
+            .sort_by(|a, b| (&a.file_path, a.sort_line()).cmp(&(&b.file_path, b.sort_line())));
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.panel_open = true;
+        self.filter = FindingFilter::All;
+    }
+
+    /// Indices of findings that match the current filter.
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        self.findings
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| match self.filter {
+                FindingFilter::All => true,
+                FindingFilter::Pending => f.status == FindingStatus::Pending,
+                FindingFilter::Accepted => f.status == FindingStatus::Accepted,
+                FindingFilter::Dismissed => f.status == FindingStatus::Dismissed,
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Total and reviewed counts for header display.
+    pub fn reviewed_count(&self) -> (usize, usize) {
+        let total = self.findings.len();
+        let reviewed = self
+            .findings
+            .iter()
+            .filter(|f| f.status != FindingStatus::Pending)
+            .count();
+        (reviewed, total)
+    }
+
+    /// Move selection to next visible finding.
+    pub fn select_next(&mut self) {
+        let indices = self.filtered_indices();
+        if indices.is_empty() {
+            return;
+        }
+        if let Some(pos) = indices.iter().position(|&i| i == self.selected) {
+            let next = (pos + 1).min(indices.len() - 1);
+            self.selected = indices[next];
+        } else if let Some(&first) = indices.first() {
+            self.selected = first;
+        }
+    }
+
+    /// Move selection to previous visible finding.
+    pub fn select_prev(&mut self) {
+        let indices = self.filtered_indices();
+        if indices.is_empty() {
+            return;
+        }
+        if let Some(pos) = indices.iter().position(|&i| i == self.selected) {
+            let prev = pos.saturating_sub(1);
+            self.selected = indices[prev];
+        } else if let Some(&last) = indices.last() {
+            self.selected = last;
+        }
+    }
+
+    pub fn has_findings(&self) -> bool {
+        !self.findings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::annotation_state::{Annotation, LineAnchor};
+
+    fn sample_annotations() -> Vec<Annotation> {
+        vec![
+            Annotation {
+                anchor: LineAnchor {
+                    file_path: "src/main.rs".to_string(),
+                    old_range: None,
+                    new_range: Some((10, 15)),
+                },
+                comment: "Potential null deref".to_string(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                category: AnnotationCategory::Bug,
+                severity: AnnotationSeverity::Critical,
+            },
+            Annotation {
+                anchor: LineAnchor {
+                    file_path: "src/lib.rs".to_string(),
+                    old_range: Some((5, 5)),
+                    new_range: Some((5, 8)),
+                },
+                comment: "Style nit".to_string(),
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                category: AnnotationCategory::Style,
+                severity: AnnotationSeverity::Info,
+            },
+        ]
+    }
+
+    #[test]
+    fn populate_creates_sorted_findings() {
+        let mut state = AutoReviewState::default();
+        state.populate(&sample_annotations());
+        assert_eq!(state.findings.len(), 2);
+        // lib.rs sorts before main.rs
+        assert_eq!(state.findings[0].file_path, "src/lib.rs");
+        assert_eq!(state.findings[1].file_path, "src/main.rs");
+        assert!(state.panel_open);
+    }
+
+    #[test]
+    fn filter_cycle() {
+        let f = FindingFilter::All;
+        assert_eq!(f.cycle(), FindingFilter::Pending);
+        assert_eq!(f.cycle().cycle(), FindingFilter::Accepted);
+        assert_eq!(f.cycle().cycle().cycle(), FindingFilter::Dismissed);
+        assert_eq!(f.cycle().cycle().cycle().cycle(), FindingFilter::All);
+    }
+
+    #[test]
+    fn reviewed_count_tracks_status() {
+        let mut state = AutoReviewState::default();
+        state.populate(&sample_annotations());
+        assert_eq!(state.reviewed_count(), (0, 2));
+        state.findings[0].status = FindingStatus::Accepted;
+        assert_eq!(state.reviewed_count(), (1, 2));
+        state.findings[1].status = FindingStatus::Dismissed;
+        assert_eq!(state.reviewed_count(), (2, 2));
+    }
+
+    #[test]
+    fn filtered_indices_respects_filter() {
+        let mut state = AutoReviewState::default();
+        state.populate(&sample_annotations());
+        state.findings[0].status = FindingStatus::Accepted;
+
+        state.filter = FindingFilter::Pending;
+        assert_eq!(state.filtered_indices(), vec![1]);
+
+        state.filter = FindingFilter::Accepted;
+        assert_eq!(state.filtered_indices(), vec![0]);
+
+        state.filter = FindingFilter::All;
+        assert_eq!(state.filtered_indices(), vec![0, 1]);
+    }
+
+    #[test]
+    fn navigation_wraps_within_filtered() {
+        let mut state = AutoReviewState::default();
+        state.populate(&sample_annotations());
+        assert_eq!(state.selected, 0);
+        state.select_next();
+        assert_eq!(state.selected, 1);
+        state.select_next();
+        assert_eq!(state.selected, 1); // stays at last
+        state.select_prev();
+        assert_eq!(state.selected, 0);
+        state.select_prev();
+        assert_eq!(state.selected, 0); // stays at first
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_state;
 pub mod annotation_state;
 pub mod app_state;
+pub mod auto_review_state;
 pub mod bookmark_state;
 pub mod checklist_state;
 pub mod command_bar_state;
@@ -17,6 +18,7 @@ pub mod worktree_state;
 pub use agent_state::{AgentOutputsState, AgentSelectorState};
 pub use annotation_state::AnnotationState;
 pub use app_state::AppState;
+pub use auto_review_state::AutoReviewState;
 pub use bookmark_state::BookmarkState;
 pub use checklist_state::{ChecklistItem, ChecklistState};
 pub use command_bar_state::CommandBarState;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User Problem
When a user triggers an agentic review in mdiff, the AI-generated findings currently stream as raw text into a side panel. There's no way to navigate individual findings, accept them as annotations, dismiss false positives, or jump to the relevant code location. Users must read through a wall of text and manually create annotations — defeating the purpose of AI-assisted review. Addresses #71.

## Planned Approach
Build an AutoReviewState that receives structured annotations from AgenticReviewComplete, presenting them as a navigable findings list in a dedicated panel. Each finding can be accepted (converting to a persistent annotation), dismissed, or edited. The panel integrates with the existing diff view for jump-to-code navigation and respects mdiff's Action enum / Component trait patterns.

## User Benefit
Transforms AI review output from passive text into an actionable triage workflow. Reviewers can process AI findings at keyboard speed — accept good ones, dismiss noise, edit imprecise suggestions — reducing the feedback loop from minutes of manual annotation to seconds of triage per finding.

## Visual Preview
[Visual mockup will be added by the ideation agent]

## Spec Reference
See `.github/specs/032-automated-review-surface.md`

## Implementation Details

### New Files
- **`src/state/auto_review_state.rs`** — `AutoReviewState` struct with `Vec<ReviewFinding>`, navigation, filtering (All/Pending/Accepted/Dismissed), and `populate()` from completed annotations. Includes `FindingStatus` (Pending/Accepted/Dismissed), `FindingFilter`, and `ReviewFinding` with `to_annotation()` conversion. 5 unit tests.
- **`src/components/auto_review_panel.rs`** — TUI component rendering findings list grouped by file with severity color coding, status indicators (●/✓/✗), selected finding detail area, and keyboard hint bar.

### Modified Files
- **`src/action.rs`** — Added 8 `AutoReview*` action variants (Next, Prev, Accept, Dismiss, Edit, JumpToCode, FilterCycle, Close)
- **`src/event.rs`** — Added `auto_review_panel_open` to `KeyContext`, key mappings at Priority 3.8 for j/k/Enter/a/x/e/f/Esc when auto-review panel is focused
- **`src/state/app_state.rs`** — Added `auto_review: AutoReviewState` field
- **`src/state/mod.rs`** — Re-exported `AutoReviewState`
- **`src/app.rs`** — Wired `AgenticReviewComplete` to populate `AutoReviewState` (findings start as Pending, not immediately added to AnnotationState); handled all `AutoReview*` actions including accept→annotation conversion, dismiss, edit via comment editor, jump-to-code via `goto_line`, and filter cycling; added auto-review panel rendering in the layout
- **`src/components/which_key.rs`** — Added auto-review panel context entries when panel is active
- **`src/components/action_hud.rs`** — Added `auto_review_panel_open` to KeyContext in tests

### Data Flow
```
AgenticReviewComplete(Vec<Annotation>)
  → AutoReviewState.populate(annotations)  // findings = Pending
  → User triages via panel (j/k navigate, a accept, x dismiss, e edit)
  → Accept: finding.status = Accepted, to_annotation() → AnnotationState
  → Dismiss: finding.status = Dismissed (grayed out)
  → Edit: opens comment editor pre-filled, on confirm → Accepted + annotation
```

### Keybindings (when auto-review panel focused)
| Key | Action |
|-----|--------|
| `j`/`k`/↑/↓ | Navigate findings |
| `Enter` | Jump to finding location in diff view |
| `a` | Accept finding (converts to persistent annotation) |
| `x` | Dismiss finding |
| `e` | Edit finding text, then accept |
| `f` | Cycle filter (All → Pending → Accepted → Dismissed) |
| `Esc` | Close panel |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6072366f-8f7a-45b2-8a18-52ea6ca32a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6072366f-8f7a-45b2-8a18-52ea6ca32a26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

