### PR TITLE
feat: add diff statistics dashboard overlay (S toggle)

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -199,6 +199,13 @@ pub enum Action {
     SettingsLeft,
     SettingsRight,
 
+    // Statistics dashboard
+    ToggleStatsDashboard,
+    StatsDashboardUp,
+    StatsDashboardDown,
+    StatsDashboardSelect,
+    StatsDashboardSort,
+
     // Feedback summary
     ToggleFeedbackSummary,
     FeedbackSummaryUp,

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,6 +297,12 @@ impl App {
 
                 action_hud.render(frame, outer[2], &self.state);
 
+                // Stats dashboard overlay (covers main content area)
+                if self.state.stats.open {
+                    use crate::components::stats_dashboard::StatsDashboard;
+                    StatsDashboard.render(frame, outer[1], &self.state);
+                }
+
                 // Render modal overlays (in priority order)
                 if self.state.target_dialog_open {
                     render_target_dialog(frame, &self.state);
@@ -390,6 +396,7 @@ impl App {
                     agentic_review_panel_open: self.state.agentic_review_panel_open,
                     agentic_review_composing: self.state.agentic_review_composing,
                     window_pending: self.window_pending,
+                    stats_dashboard_open: self.state.stats.open,
                 };
                 let action = match event {
                     Event::Key(key) => {
@@ -2512,6 +2519,48 @@ impl App {
                 }
             }
 
+            // Statistics dashboard
+            Action::ToggleStatsDashboard => {
+                self.state.stats.open = !self.state.stats.open;
+                if self.state.stats.open {
+                    self.state.stats.scroll_offset = 0;
+                    self.state.stats.selected_index = 0;
+                    self.recompute_diff_summary();
+                }
+            }
+            Action::StatsDashboardUp => {
+                if self.state.stats.selected_index > 0 {
+                    self.state.stats.selected_index -= 1;
+                }
+            }
+            Action::StatsDashboardDown => {
+                let file_count = self
+                    .state
+                    .stats
+                    .diff_summary
+                    .as_ref()
+                    .map(|s| s.total_files)
+                    .unwrap_or(0);
+                if file_count > 0 && self.state.stats.selected_index < file_count - 1 {
+                    self.state.stats.selected_index += 1;
+                }
+            }
+            Action::StatsDashboardSelect => {
+                if let Some(ref summary) = self.state.stats.diff_summary {
+                    let sorted = summary.sorted_file_stats(self.state.stats.sort_mode);
+                    if let Some(file) = sorted.get(self.state.stats.selected_index) {
+                        let delta_index = file.delta_index;
+                        self.state.stats.open = false;
+                        self.update(Action::SelectFile(delta_index));
+                        self.state.focus = FocusPanel::DiffView;
+                    }
+                }
+            }
+            Action::StatsDashboardSort => {
+                self.state.stats.sort_mode = self.state.stats.sort_mode.next();
+                self.state.stats.selected_index = 0;
+            }
+
             // Feedback summary
             Action::ToggleFeedbackSummary => {
                 if self.state.active_view == ActiveView::FeedbackSummary {
@@ -3241,6 +3290,11 @@ impl App {
                 self.set_status(format!("Failed to list worktrees: {e}"), true);
             }
         }
+    }
+
+    fn recompute_diff_summary(&mut self) {
+        use crate::state::stats_state::DiffSummary;
+        self.state.stats.diff_summary = Some(DiffSummary::from_deltas(&self.state.diff.deltas));
     }
 
     fn set_status(&mut self, msg: String, is_error: bool) {

--- a/src/components/action_hud.rs
+++ b/src/components/action_hud.rs
@@ -349,6 +349,7 @@ mod tests {
             agentic_review_panel_open: state.agentic_review_panel_open,
             agentic_review_composing: state.agentic_review_composing,
             window_pending: false,
+            stats_dashboard_open: state.stats.open,
         }
     }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,6 +18,7 @@ pub mod navigator;
 pub mod prompt_preview;
 pub mod restore_confirm;
 pub mod settings_modal;
+pub mod stats_dashboard;
 pub mod target_dialog;
 pub mod text_input;
 pub mod which_key;

--- a/src/components/stats_dashboard.rs
+++ b/src/components/stats_dashboard.rs
@@ -1,0 +1,319 @@
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::git::types::FileStatus;
+use crate::state::AppState;
+
+use super::Component;
+
+pub struct StatsDashboard;
+
+impl Component for StatsDashboard {
+    fn render(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        let theme = &state.theme;
+        let block = Block::default()
+            .title(" Diff Statistics ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.accent));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let summary = match &state.stats.diff_summary {
+            Some(s) => s,
+            None => {
+                let empty = Paragraph::new("  No changes to display")
+                    .style(Style::default().fg(theme.text_muted));
+                frame.render_widget(empty, inner);
+                return;
+            }
+        };
+
+        if summary.total_files == 0 {
+            let empty = Paragraph::new("  No changes to display")
+                .style(Style::default().fg(theme.text_muted));
+            frame.render_widget(empty, inner);
+            return;
+        }
+
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Header: aggregate stats
+        lines.push(Line::from(""));
+
+        let mut status_parts: Vec<String> = Vec::new();
+        if summary.files_added > 0 {
+            status_parts.push(format!("{} added", summary.files_added));
+        }
+        if summary.files_modified > 0 {
+            status_parts.push(format!("{} modified", summary.files_modified));
+        }
+        if summary.files_deleted > 0 {
+            status_parts.push(format!("{} deleted", summary.files_deleted));
+        }
+        if summary.files_renamed > 0 {
+            status_parts.push(format!("{} renamed", summary.files_renamed));
+        }
+        let status_text = if status_parts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", status_parts.join(", "))
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled("  Files: ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                format!("{} changed", summary.total_files),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(status_text, Style::default().fg(theme.text_muted)),
+        ]));
+
+        let net = summary.total_additions as i64 - summary.total_deletions as i64;
+        let net_str = if net >= 0 {
+            format!("net +{}", net)
+        } else {
+            format!("net {}", net)
+        };
+        lines.push(Line::from(vec![
+            Span::styled("  Lines: ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                format!("+{}", format_number(summary.total_additions)),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                format!("-{}", format_number(summary.total_deletions)),
+                Style::default().fg(Color::Red),
+            ),
+            Span::styled(
+                format!("  ({})", net_str),
+                Style::default().fg(theme.text_muted),
+            ),
+        ]));
+
+        // File type breakdown
+        if !summary.by_extension.is_empty() {
+            let ext_spans: Vec<Span> = summary
+                .by_extension
+                .iter()
+                .take(8)
+                .enumerate()
+                .flat_map(|(i, (ext, count))| {
+                    let mut spans = Vec::new();
+                    if i > 0 {
+                        spans.push(Span::raw("  "));
+                    }
+                    spans.push(Span::styled(
+                        format!("{ext} ({count})"),
+                        Style::default().fg(ext_color(i)),
+                    ));
+                    spans
+                })
+                .collect();
+
+            let mut type_line = vec![Span::styled(
+                "  Types: ",
+                Style::default().fg(theme.text_muted),
+            )];
+            type_line.extend(ext_spans);
+            lines.push(Line::from(type_line));
+        }
+
+        lines.push(Line::from(""));
+
+        // Sort indicator
+        let sort_label = state.stats.sort_mode.label();
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  Sort: {} ▾", sort_label),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  [s] cycle sort", Style::default().fg(theme.text_muted)),
+        ]));
+
+        // Separator
+        let sep_width = inner.width.saturating_sub(2) as usize;
+        lines.push(Line::from(Span::styled(
+            format!("  {}", "─".repeat(sep_width.saturating_sub(2))),
+            Style::default().fg(theme.text_muted),
+        )));
+
+        // File list
+        let sorted_stats = summary.sorted_file_stats(state.stats.sort_mode);
+        let max_churn = sorted_stats
+            .iter()
+            .map(|f| f.churn())
+            .max()
+            .unwrap_or(1)
+            .max(1);
+
+        let bar_width = 10usize;
+        let avail_width = inner.width as usize;
+
+        for (i, file) in sorted_stats.iter().enumerate() {
+            let is_selected = i == state.stats.selected_index;
+
+            let marker = if is_selected { " ▸ " } else { "   " };
+
+            let status_badge = match file.status {
+                FileStatus::Added => "[A] ",
+                FileStatus::Deleted => "[D] ",
+                FileStatus::Renamed => "[R→] ",
+                FileStatus::Untracked => "[?] ",
+                FileStatus::Modified => "",
+            };
+
+            let display_path = truncate_path(&file.path, avail_width.saturating_sub(40));
+
+            let additions_str = if file.binary {
+                "binary".to_string()
+            } else {
+                format!("+{}", file.additions)
+            };
+            let deletions_str = if file.binary {
+                String::new()
+            } else {
+                format!("-{}", file.deletions)
+            };
+
+            let churn = file.churn();
+            let filled = if max_churn > 0 {
+                churn * bar_width / max_churn
+            } else {
+                0
+            };
+            let add_portion = if churn > 0 {
+                file.additions * filled / churn.max(1)
+            } else {
+                0
+            };
+            let del_portion = filled.saturating_sub(add_portion);
+            let empty = bar_width.saturating_sub(filled);
+
+            let add_bar = "█".repeat(add_portion);
+            let del_bar = "█".repeat(del_portion);
+            let empty_bar = "░".repeat(empty);
+
+            let highlight_style = if is_selected {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text)
+            };
+
+            let status_color = match file.status {
+                FileStatus::Added => Color::Green,
+                FileStatus::Deleted => Color::Red,
+                FileStatus::Renamed => Color::Yellow,
+                _ => theme.text_muted,
+            };
+
+            let mut spans = vec![
+                Span::styled(marker, highlight_style),
+                Span::styled(status_badge.to_string(), Style::default().fg(status_color)),
+                Span::styled(display_path, highlight_style),
+            ];
+
+            let padding = "  ";
+            spans.push(Span::raw(padding));
+            spans.push(Span::styled(
+                format!("{:<6}", additions_str),
+                Style::default().fg(Color::Green),
+            ));
+            spans.push(Span::styled(
+                format!("{:<6}", deletions_str),
+                Style::default().fg(Color::Red),
+            ));
+            spans.push(Span::styled(add_bar, Style::default().fg(Color::Green)));
+            spans.push(Span::styled(del_bar, Style::default().fg(Color::Red)));
+            spans.push(Span::styled(
+                empty_bar,
+                Style::default().fg(theme.text_muted),
+            ));
+
+            lines.push(Line::from(spans));
+        }
+
+        lines.push(Line::from(""));
+
+        // Footer with key bindings
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  [j/k]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" navigate  "),
+            Span::styled(
+                "[Enter]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" jump to file  "),
+            Span::styled(
+                "[s]",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" sort  "),
+            Span::styled("[Esc]", Style::default().fg(theme.text_muted)),
+            Span::raw(" close"),
+        ]));
+
+        let visible_lines: Vec<Line> = lines.into_iter().skip(state.stats.scroll_offset).collect();
+
+        let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
+        frame.render_widget(paragraph, inner);
+    }
+}
+
+fn format_number(n: usize) -> String {
+    if n >= 1_000_000 {
+        format!(
+            "{},{:03},{:03}",
+            n / 1_000_000,
+            (n / 1_000) % 1_000,
+            n % 1_000
+        )
+    } else if n >= 1_000 {
+        format!("{},{:03}", n / 1_000, n % 1_000)
+    } else {
+        n.to_string()
+    }
+}
+
+fn ext_color(index: usize) -> Color {
+    const COLORS: &[Color] = &[
+        Color::Cyan,
+        Color::Yellow,
+        Color::Green,
+        Color::Magenta,
+        Color::Blue,
+        Color::Red,
+        Color::LightCyan,
+        Color::LightYellow,
+    ];
+    COLORS[index % COLORS.len()]
+}
+
+fn truncate_path(path: &str, max_len: usize) -> String {
+    if path.len() <= max_len || max_len < 4 {
+        return path.to_string();
+    }
+    let take = max_len.saturating_sub(3);
+    format!("…{}", &path[path.len() - take..])
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -120,6 +120,7 @@ pub struct KeyContext {
     pub agentic_review_panel_open: bool,
     pub agentic_review_composing: bool,
     pub window_pending: bool,
+    pub stats_dashboard_open: bool,
 }
 
 /// Context for mouse event mapping.
@@ -414,6 +415,18 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
         };
     }
 
+    // Priority 2.37: Stats dashboard overlay
+    if ctx.stats_dashboard_open {
+        return match key.code {
+            KeyCode::Esc | KeyCode::Char('S') => Some(Action::ToggleStatsDashboard),
+            KeyCode::Up | KeyCode::Char('k') => Some(Action::StatsDashboardUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(Action::StatsDashboardDown),
+            KeyCode::Enter => Some(Action::StatsDashboardSelect),
+            KeyCode::Char('s') => Some(Action::StatsDashboardSort),
+            _ => None,
+        };
+    }
+
     // Priority 2.4: Checklist panel navigation
     if ctx.checklist_panel_open {
         return match key.code {
@@ -699,6 +712,9 @@ pub fn map_key_to_action(key: KeyEvent, ctx: &KeyContext) -> Option<Action> {
                 return Some(Action::SwitchToAgentOutputs)
             }
             KeyCode::Char('F') => return Some(Action::ToggleFeedbackSummary),
+            KeyCode::Char('S') if !ctx.visual_mode_active => {
+                return Some(Action::ToggleStatsDashboard)
+            }
             KeyCode::Char('R') => return Some(Action::RefreshDiff),
             KeyCode::Char('n') if !ctx.visual_mode_active => {
                 return match ctx.focus {
@@ -905,6 +921,7 @@ mod tests {
             agentic_review_panel_open: false,
             agentic_review_composing: false,
             window_pending: false,
+            stats_dashboard_open: false,
         }
     }
 
@@ -940,6 +957,7 @@ mod tests {
             agentic_review_panel_open: false,
             agentic_review_composing: false,
             window_pending: false,
+            stats_dashboard_open: false,
         }
     }
 
@@ -975,6 +993,7 @@ mod tests {
             agentic_review_panel_open: true,
             agentic_review_composing: true,
             window_pending: false,
+            stats_dashboard_open: false,
         }
     }
 

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -3,7 +3,7 @@ use crate::theme::Theme;
 use super::{
     AgentOutputsState, AgentSelectorState, AnnotationState, BookmarkState, ChecklistState,
     CommandBarState, DiffOptions, DiffState, FilePickerState, GlobalSearchState, NavigatorState,
-    ReviewState, SelectionState, TextBuffer, WorktreeState,
+    ReviewState, SelectionState, StatsState, TextBuffer, WorktreeState,
 };
 
 use super::annotation_state::{AnnotationCategory, AnnotationSeverity};
@@ -157,6 +157,9 @@ pub struct AppState {
     // File picker (Ctrl+P)
     pub file_picker: FilePickerState,
 
+    // Stats dashboard
+    pub stats: StatsState,
+
     // Agentic review
     pub agentic_review_modal_open: bool, // kept for KeyContext compat, always false now
     pub agentic_review_composing: bool,
@@ -214,6 +217,7 @@ impl AppState {
             bookmarks: BookmarkState::new(),
             command_bar: CommandBarState::new(),
             file_picker: FilePickerState::new(),
+            stats: StatsState::default(),
             agentic_review_modal_open: false,
             agentic_review_composing: false,
             agentic_review_text: TextBuffer::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,6 +11,7 @@ pub mod review_state;
 pub mod search_state;
 pub mod selection_state;
 pub mod settings_state;
+pub mod stats_state;
 pub mod text_buffer;
 pub mod worktree_state;
 
@@ -26,5 +27,6 @@ pub use navigator_state::NavigatorState;
 pub use review_state::ReviewState;
 pub use search_state::GlobalSearchState;
 pub use selection_state::SelectionState;
+pub use stats_state::StatsState;
 pub use text_buffer::TextBuffer;
 pub use worktree_state::WorktreeState;

--- a/src/state/stats_state.rs
+++ b/src/state/stats_state.rs
@@ -1,0 +1,153 @@
+use crate::git::types::{FileDelta, FileStatus};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortMode {
+    Churn,
+    Additions,
+    Name,
+}
+
+impl SortMode {
+    pub fn next(self) -> Self {
+        match self {
+            SortMode::Churn => SortMode::Additions,
+            SortMode::Additions => SortMode::Name,
+            SortMode::Name => SortMode::Churn,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            SortMode::Churn => "by churn",
+            SortMode::Additions => "by additions",
+            SortMode::Name => "by name",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FileStats {
+    pub path: String,
+    #[allow(dead_code)]
+    pub old_path: Option<String>,
+    pub additions: usize,
+    pub deletions: usize,
+    pub status: FileStatus,
+    pub binary: bool,
+    pub delta_index: usize,
+}
+
+impl FileStats {
+    pub fn churn(&self) -> usize {
+        self.additions + self.deletions
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiffSummary {
+    pub total_files: usize,
+    pub total_additions: usize,
+    pub total_deletions: usize,
+    pub files_added: usize,
+    pub files_modified: usize,
+    pub files_deleted: usize,
+    pub files_renamed: usize,
+    pub by_extension: Vec<(String, usize)>,
+    pub file_stats: Vec<FileStats>,
+}
+
+impl DiffSummary {
+    pub fn from_deltas(deltas: &[FileDelta]) -> Self {
+        let mut total_additions = 0usize;
+        let mut total_deletions = 0usize;
+        let mut files_added = 0usize;
+        let mut files_modified = 0usize;
+        let mut files_deleted = 0usize;
+        let mut files_renamed = 0usize;
+        let mut ext_counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        let mut file_stats = Vec::with_capacity(deltas.len());
+
+        for (i, delta) in deltas.iter().enumerate() {
+            total_additions += delta.additions;
+            total_deletions += delta.deletions;
+
+            match delta.status {
+                FileStatus::Added => files_added += 1,
+                FileStatus::Modified => files_modified += 1,
+                FileStatus::Deleted => files_deleted += 1,
+                FileStatus::Renamed => files_renamed += 1,
+                FileStatus::Untracked => files_added += 1,
+            }
+
+            let ext = delta
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| format!(".{e}"))
+                .unwrap_or_else(|| "other".to_string());
+            *ext_counts.entry(ext).or_insert(0) += 1;
+
+            file_stats.push(FileStats {
+                path: delta.path.to_string_lossy().to_string(),
+                old_path: delta
+                    .old_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().to_string()),
+                additions: delta.additions,
+                deletions: delta.deletions,
+                status: delta.status.clone(),
+                binary: delta.binary,
+                delta_index: i,
+            });
+        }
+
+        file_stats.sort_by_key(|f| std::cmp::Reverse(f.churn()));
+
+        let mut by_extension: Vec<(String, usize)> = ext_counts.into_iter().collect();
+        by_extension.sort_by(|a, b| b.1.cmp(&a.1));
+
+        DiffSummary {
+            total_files: deltas.len(),
+            total_additions,
+            total_deletions,
+            files_added,
+            files_modified,
+            files_deleted,
+            files_renamed,
+            by_extension,
+            file_stats,
+        }
+    }
+
+    pub fn sorted_file_stats(&self, mode: SortMode) -> Vec<FileStats> {
+        let mut stats = self.file_stats.clone();
+        match mode {
+            SortMode::Churn => stats.sort_by_key(|f| std::cmp::Reverse(f.churn())),
+            SortMode::Additions => stats.sort_by_key(|f| std::cmp::Reverse(f.additions)),
+            SortMode::Name => stats.sort_by(|a, b| a.path.cmp(&b.path)),
+        }
+        stats
+    }
+}
+
+#[derive(Debug)]
+pub struct StatsState {
+    pub open: bool,
+    pub scroll_offset: usize,
+    pub selected_index: usize,
+    pub sort_mode: SortMode,
+    pub diff_summary: Option<DiffSummary>,
+}
+
+impl Default for StatsState {
+    fn default() -> Self {
+        Self {
+            open: false,
+            scroll_offset: 0,
+            selected_index: 0,
+            sort_mode: SortMode::Churn,
+            diff_summary: None,
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User Problem
When a coding agent modifies 30+ files across a large changeset, reviewers have no way to quickly assess the scope and shape of changes before diving into line-by-line review. They must scroll through every file in the navigator, mentally tallying which files have the most churn and what types of files are affected. This leads to poor review prioritization — reviewers may spend time on low-impact config changes while missing critical logic modifications buried in the file list.

## Planned Approach
Add a full-screen statistics dashboard overlay (toggled with S) that computes and displays aggregate diff statistics from the existing DiffState data. The dashboard has two sections: a header showing total files/additions/deletions/file type breakdown, and a scrollable per-file list with sparkline bars proportional to churn. Users can sort by churn/additions/name (s key), navigate with j/k, and jump directly to any file with Enter. New types: StatsState, DiffSummary, FileStats, SortMode. New component: stats_dashboard overlay.

## User Benefit
Transforms the first 5 seconds of every review session from blind scrolling to informed prioritization. Reviewers instantly see which files have the most churn, what the change distribution looks like, and can jump directly to high-impact files. For large agent changesets (30+ files), this reduces the time to orient from minutes to seconds and ensures no high-churn files are accidentally skipped.

## Visual Preview
Visual mockup will be added by the ideation agent

## Spec Reference
See `.github/specs/019-diff-statistics-dashboard.md`

## Changes

### New files
- **`src/state/stats_state.rs`**: `StatsState`, `DiffSummary`, `FileStats`, `SortMode` types. `DiffSummary::from_deltas()` computes aggregate stats from existing `FileDelta` data.
- **`src/components/stats_dashboard.rs`**: Full-screen overlay component rendering header stats, file type breakdown, and per-file sparkline bars.

### Modified files
- **`src/action.rs`**: 5 new action variants (`ToggleStatsDashboard`, `StatsDashboardUp/Down`, `StatsDashboardSelect`, `StatsDashboardSort`)
- **`src/event.rs`**: `stats_dashboard_open` field in `KeyContext`, priority handler for dashboard keys, `S` trigger in global bindings
- **`src/state/app_state.rs`**: `stats: StatsState` field
- **`src/state/mod.rs`**: Register `stats_state` module
- **`src/components/mod.rs`**: Register `stats_dashboard` module
- **`src/app.rs`**: Action dispatch, overlay rendering, `recompute_diff_summary()` helper
- **`src/components/action_hud.rs`**: `KeyContext` compatibility for tests

## Testing
- `cargo fmt --all --check` passes
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo test` passes (all 66 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1960145-5795-494e-adcf-954cfd47720a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1960145-5795-494e-adcf-954cfd47720a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

