### PR TITLE
fix: add boundary padding rows and fix scroll clipping at bottom (#25)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -726,16 +726,16 @@ impl App {
 
         let metrics = match self.state.diff.options.view_mode {
             DiffViewMode::Split => {
-                let halves = Layout::default()
+                let gutter_width_chars: u16 = 12;
+                let cols = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                    .constraints([
+                        Constraint::Min(10),
+                        Constraint::Length(gutter_width_chars),
+                        Constraint::Min(10),
+                    ])
                     .split(inner);
-                compute_split_visual_row_metrics(
-                    delta,
-                    &self.state,
-                    halves[0].width,
-                    halves[1].width,
-                )
+                compute_split_visual_row_metrics(delta, &self.state, cols[0].width, cols[2].width)
             }
             DiffViewMode::Unified => {
                 compute_unified_visual_row_metrics(delta, &self.state, inner.width)
@@ -3079,6 +3079,8 @@ impl App {
                 // Don't re-enable auto_scroll — user is manually scrolling
             }
         }
+
+        self.clamp_scroll();
     }
 
     /// Return a mutable reference to whichever TextBuffer is currently active,

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -401,6 +401,33 @@ fn build_split_lines_core<'a>(
     let gutter_width = 5;
     let mut gap_id_offset = 0;
 
+    let filename = delta.path.to_string_lossy();
+
+    // Boundary start row
+    if display_map
+        .get(display_row)
+        .is_some_and(|r| r.is_boundary_start)
+    {
+        let hl = row_highlight(state, display_row);
+        let boundary_text =
+            format!("\u{2500}\u{2500}\u{2500} diff start: {filename} \u{2500}\u{2500}\u{2500}");
+        let mut style = Style::default()
+            .fg(theme.text_muted)
+            .add_modifier(Modifier::DIM);
+        if let Some(bg) = hl.content_bg {
+            style = style.bg(bg);
+        }
+        left.push(Line::from(Span::styled(boundary_text, style)));
+        let empty_gutter = format!("{:>gutter_width$} {:>gutter_width$} ", "", "");
+        let mut gutter_style = Style::default().fg(theme.text_muted);
+        if let Some(bg) = hl.gutter_bg {
+            gutter_style = gutter_style.bg(bg);
+        }
+        center.push(Line::from(Span::styled(empty_gutter, gutter_style)));
+        right.push(Line::from(Span::styled("", style)));
+        display_row += 1;
+    }
+
     for hunk in &delta.hunks {
         let hl = row_highlight(state, display_row);
         let ann_marker = display_map
@@ -673,6 +700,30 @@ fn build_split_lines_core<'a>(
         }
     }
 
+    // Boundary end row
+    if display_map
+        .get(display_row)
+        .is_some_and(|r| r.is_boundary_end)
+    {
+        let hl = row_highlight(state, display_row);
+        let boundary_text =
+            format!("\u{2500}\u{2500}\u{2500} diff end: {filename} \u{2500}\u{2500}\u{2500}");
+        let mut style = Style::default()
+            .fg(theme.text_muted)
+            .add_modifier(Modifier::DIM);
+        if let Some(bg) = hl.content_bg {
+            style = style.bg(bg);
+        }
+        left.push(Line::from(Span::styled(boundary_text, style)));
+        let empty_gutter = format!("{:>gutter_width$} {:>gutter_width$} ", "", "");
+        let mut gutter_style = Style::default().fg(theme.text_muted);
+        if let Some(bg) = hl.gutter_bg {
+            gutter_style = gutter_style.bg(bg);
+        }
+        center.push(Line::from(Span::styled(empty_gutter, gutter_style)));
+        right.push(Line::from(Span::styled("", style)));
+    }
+
     (left, center, right)
 }
 
@@ -688,6 +739,23 @@ fn build_unified_lines_core<'a>(
     let mut lines: Vec<Line> = Vec::new();
     let mut display_row: usize = 0;
     let mut gap_id_offset = 0;
+
+    let filename = delta.path.to_string_lossy();
+
+    // Boundary start row
+    if display_map
+        .get(display_row)
+        .is_some_and(|r| r.is_boundary_start)
+    {
+        let hl = row_highlight(state, display_row);
+        lines.push(make_boundary_line_unified(
+            gutter_width,
+            &format!("\u{2500}\u{2500}\u{2500} diff start: {filename} \u{2500}\u{2500}\u{2500}"),
+            hl,
+            theme,
+        ));
+        display_row += 1;
+    }
 
     for hunk in &delta.hunks {
         let hl = row_highlight(state, display_row);
@@ -810,6 +878,20 @@ fn build_unified_lines_core<'a>(
                 }
             }
         }
+    }
+
+    // Boundary end row
+    if display_map
+        .get(display_row)
+        .is_some_and(|r| r.is_boundary_end)
+    {
+        let hl = row_highlight(state, display_row);
+        lines.push(make_boundary_line_unified(
+            gutter_width,
+            &format!("\u{2500}\u{2500}\u{2500} diff end: {filename} \u{2500}\u{2500}\u{2500}"),
+            hl,
+            theme,
+        ));
     }
 
     lines
@@ -1086,6 +1168,33 @@ fn make_unified_highlighted<'a>(
     all_spans.push(prefix_span);
     all_spans.extend(content_spans);
     Line::from(all_spans)
+}
+
+/// Build a boundary marker line for unified view (dim/muted style, no line numbers).
+fn make_boundary_line_unified<'a>(
+    gutter_width: usize,
+    text: &str,
+    hl: RowHighlight,
+    theme: &Theme,
+) -> Line<'a> {
+    let gutter_text = format!("{:>gutter_width$} {:>gutter_width$} ", "", "");
+    let mut gutter_style = Style::default().fg(theme.text_muted);
+    if let Some(fg) = hl.gutter_fg {
+        gutter_style = gutter_style.fg(fg);
+    }
+    if let Some(bg) = hl.gutter_bg {
+        gutter_style = gutter_style.bg(bg);
+    }
+    let mut content_style = Style::default()
+        .fg(theme.text_muted)
+        .add_modifier(Modifier::DIM);
+    if let Some(bg) = hl.content_bg {
+        content_style = content_style.bg(bg);
+    }
+    Line::from(vec![
+        Span::styled(gutter_text, gutter_style),
+        Span::styled(text.to_string(), content_style),
+    ])
 }
 
 /// Build a collapsed indicator line for unified view.
@@ -1538,9 +1647,10 @@ mod tests {
 
         let metrics = compute_split_visual_row_metrics(&delta, &state, 12, 12);
 
-        assert_eq!(metrics.row_offsets.len(), 2);
-        assert_eq!(metrics.row_heights.len(), 2);
-        assert!(metrics.row_heights[1] > 1, "paired row should wrap");
+        // boundary_start + hunk_header + content_line + boundary_end = 4
+        assert_eq!(metrics.row_offsets.len(), 4);
+        assert_eq!(metrics.row_heights.len(), 4);
+        assert!(metrics.row_heights[2] > 1, "paired row should wrap");
         assert_eq!(
             metrics.total_rows,
             metrics.row_heights.iter().sum::<usize>()
@@ -1563,9 +1673,10 @@ mod tests {
 
         let metrics = compute_unified_visual_row_metrics(&delta, &state, 16);
 
-        assert_eq!(metrics.row_offsets.len(), 2);
-        assert_eq!(metrics.row_heights.len(), 2);
-        assert!(metrics.row_heights[1] > 1, "content row should wrap");
+        // boundary_start + hunk_header + content_line + boundary_end = 4
+        assert_eq!(metrics.row_offsets.len(), 4);
+        assert_eq!(metrics.row_heights.len(), 4);
+        assert!(metrics.row_heights[2] > 1, "content row should wrap");
         assert_eq!(
             metrics.total_rows,
             metrics.row_heights.iter().sum::<usize>()

--- a/src/display_map.rs
+++ b/src/display_map.rs
@@ -211,6 +211,44 @@ pub struct DisplayRowInfo {
     pub hidden_count: usize,
     /// Expand direction for collapsed indicators.
     pub expand_direction: Option<ExpandDirection>,
+    /// Whether this is a boundary start marker row.
+    pub is_boundary_start: bool,
+    /// Whether this is a boundary end marker row.
+    pub is_boundary_end: bool,
+}
+
+fn boundary_start_row() -> DisplayRowInfo {
+    DisplayRowInfo {
+        hunk_index: 0,
+        line_index: None,
+        old_lineno: None,
+        new_lineno: None,
+        origin: None,
+        is_header: false,
+        is_collapsed_indicator: false,
+        gap_id: None,
+        hidden_count: 0,
+        expand_direction: None,
+        is_boundary_start: true,
+        is_boundary_end: false,
+    }
+}
+
+fn boundary_end_row(last_hunk_idx: usize) -> DisplayRowInfo {
+    DisplayRowInfo {
+        hunk_index: last_hunk_idx,
+        line_index: None,
+        old_lineno: None,
+        new_lineno: None,
+        origin: None,
+        is_header: false,
+        is_collapsed_indicator: false,
+        gap_id: None,
+        hidden_count: 0,
+        expand_direction: None,
+        is_boundary_start: false,
+        is_boundary_end: true,
+    }
 }
 
 /// Build a display map for the split view.
@@ -221,6 +259,8 @@ pub fn build_split_display_map(
 ) -> Vec<DisplayRowInfo> {
     let mut rows = Vec::new();
     let mut gap_id_offset = 0;
+
+    rows.push(boundary_start_row());
 
     for (hunk_idx, hunk) in delta.hunks.iter().enumerate() {
         // Hunk header row
@@ -235,6 +275,8 @@ pub fn build_split_display_map(
             gap_id: None,
             hidden_count: 0,
             expand_direction: None,
+            is_boundary_start: false,
+            is_boundary_end: false,
         });
 
         let (items, next_offset) =
@@ -260,6 +302,8 @@ pub fn build_split_display_map(
                         gap_id: Some(*gap_id),
                         hidden_count: *hidden_count,
                         expand_direction: Some(*direction),
+                        is_boundary_start: false,
+                        is_boundary_end: false,
                     });
                     i += 1;
                 }
@@ -279,6 +323,8 @@ pub fn build_split_display_map(
                             gap_id: None,
                             hidden_count: 0,
                             expand_direction: None,
+                            is_boundary_start: false,
+                            is_boundary_end: false,
                         });
                         i += 1;
                     }
@@ -372,6 +418,8 @@ pub fn build_split_display_map(
                                 gap_id: None,
                                 hidden_count: 0,
                                 expand_direction: None,
+                                is_boundary_start: false,
+                                is_boundary_end: false,
                             });
                         }
                     }
@@ -387,6 +435,8 @@ pub fn build_split_display_map(
                             gap_id: None,
                             hidden_count: 0,
                             expand_direction: None,
+                            is_boundary_start: false,
+                            is_boundary_end: false,
                         });
                         i += 1;
                     }
@@ -394,6 +444,9 @@ pub fn build_split_display_map(
             }
         }
     }
+
+    let last_hunk = delta.hunks.len().saturating_sub(1);
+    rows.push(boundary_end_row(last_hunk));
 
     rows
 }
@@ -406,6 +459,8 @@ pub fn build_unified_display_map(
 ) -> Vec<DisplayRowInfo> {
     let mut rows = Vec::new();
     let mut gap_id_offset = 0;
+
+    rows.push(boundary_start_row());
 
     for (hunk_idx, hunk) in delta.hunks.iter().enumerate() {
         // Hunk header row
@@ -420,6 +475,8 @@ pub fn build_unified_display_map(
             gap_id: None,
             hidden_count: 0,
             expand_direction: None,
+            is_boundary_start: false,
+            is_boundary_end: false,
         });
 
         let (items, next_offset) =
@@ -444,6 +501,8 @@ pub fn build_unified_display_map(
                         gap_id: Some(*gap_id),
                         hidden_count: *hidden_count,
                         expand_direction: Some(*direction),
+                        is_boundary_start: false,
+                        is_boundary_end: false,
                     });
                 }
                 FilteredItem::Line {
@@ -461,11 +520,16 @@ pub fn build_unified_display_map(
                         gap_id: None,
                         hidden_count: 0,
                         expand_direction: None,
+                        is_boundary_start: false,
+                        is_boundary_end: false,
                     });
                 }
             }
         }
     }
+
+    let last_hunk = delta.hunks.len().saturating_sub(1);
+    rows.push(boundary_end_row(last_hunk));
 
     rows
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User Problem
Users report that pressing G (ScrollToBottom) in the diff view still cuts off the last several lines of the diff, even after the previous fix in PR #50. This has been reported twice on Issue #25 with increasing frustration. Additionally, there is no visual signal telling reviewers whether they're seeing the complete diff or if content is clipped — they must guess. This directly undermines trust in the tool for thorough code review of agent output.

Addresses #25

## Planned Approach
Two-part fix: (1) Correct the scroll bound calculation in clamp_scroll() to properly account for block borders, title rows, and status bars when computing viewport_inner_height. (2) Add BoundaryStart/BoundaryEnd display row variants to the display map, inserting dim-styled "diff start/end" markers at file boundaries. These boundary rows are counted in total_display_rows, which inherently fixes the off-by-N scroll issue. Finally, ensure clamp_scroll() is called universally after every scroll action.

## User Benefit
Reviewers can trust that pressing G shows the complete diff — no hidden content below the viewport. The boundary padding lines provide unambiguous visual confirmation that the diff is fully rendered, eliminating the "is there more?" uncertainty. This is a prerequisite for trustworthy code review of large agent changesets.

## Visual Preview

### Split View — Diff Start Boundary (top)
[Split view with diff start boundary line at top](https://cursor.com/agents/bc-070ef633-056e-4e85-8467-45242ba54862/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01-initial-view-diff-start-boundary.webp)

### Split View — Diff End Boundary (bottom, after pressing G)
[Split view scrolled to bottom showing diff end boundary line](https://cursor.com/agents/bc-070ef633-056e-4e85-8467-45242ba54862/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02-bottom-view-diff-end-boundary.webp)

### Unified View — Diff Start Boundary (top)
[Unified view with diff start boundary line](https://cursor.com/agents/bc-070ef633-056e-4e85-8467-45242ba54862/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04-unified-view-diff-start-boundary.webp)

### Unified View — Diff End Boundary (bottom, after pressing G)
[Unified view scrolled to bottom showing diff end boundary line](https://cursor.com/agents/bc-070ef633-056e-4e85-8467-45242ba54862/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F05-unified-view-bottom-diff-end-boundary.webp)

## Spec Reference
See `.github/specs/035-fix-diff-scroll-boundary-padding.md`

## Changes

### `src/display_map.rs`
- Added `is_boundary_start` and `is_boundary_end` fields to `DisplayRowInfo`
- Added `boundary_start_row()` and `boundary_end_row()` helper constructors
- Modified `build_split_display_map()` to insert boundary start/end rows
- Modified `build_unified_display_map()` to insert boundary start/end rows

### `src/components/diff_view.rs`
- Added `make_boundary_line_unified()` helper for rendering boundary rows in unified view
- Added boundary start/end row rendering in `build_split_lines_core()` (dim/muted style, no line numbers)
- Added boundary start/end row rendering in `build_unified_lines_core()`
- Updated test assertions to account for new boundary rows (+2 rows per file)

### `src/app.rs`
- Fixed split mode width calculation in `update_diff_visual_metrics()` to use the actual 3-column layout (`Min(10)/Length(12)/Min(10)`) matching the render path, instead of an incorrect 50/50 split
- Added universal `self.clamp_scroll()` call at the end of `update()` to ensure scroll bounds are always respected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-070ef633-056e-4e85-8467-45242ba54862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-070ef633-056e-4e85-8467-45242ba54862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

